### PR TITLE
fix(nov-132): stop panicking on the request path

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
 
@@ -40,6 +41,13 @@ jobs:
 
       - name: Clippy (warnings are errors)
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      # src/worker_rt.rs is cfg(target_arch = "wasm32"), so the native run above
+      # never compiles it. Without this step the crate-level
+      # deny(clippy::unwrap_used, clippy::expect_used) does not reach the Worker
+      # runtime at all.
+      - name: Clippy on the Worker target
+        run: cargo clippy --target wasm32-unknown-unknown --lib --all-features -- -D warnings
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,13 @@ name: Rust
 on:
   push:
     branches: [ "main" ]
+  # Stacked PRs target the branch below them, not `main`. Without listing those
+  # bases here the gate silently does not run on them at all: the PR shows only
+  # the Docker check and looks green while nothing has been compiled or tested.
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - "main"
+      - "feat/novaguard-platform-bridge"
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1186,7 +1186,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1566,7 +1566,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1779,7 +1779,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -1817,9 +1817,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,10 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
+    #[allow(
+        clippy::expect_used,
+        reason = "startup: a non-numeric PORT must abort the boot, not serve on a surprise port"
+    )]
     pub fn new() -> Self {
         info!("Loading environment configuration");
         dotenv::dotenv().ok();

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,9 @@ pub enum AppError {
     #[error("HTTP error: {0}")]
     HttpError(String),
 
+    #[error("Failed to build HTTP response: {0}")]
+    HttpBuildError(#[from] http::Error),
+
     #[error("JSON parse error: {0}")]
     JsonParseError(String),
 
@@ -141,6 +144,10 @@ impl IntoResponse for AppError {
             AppError::HttpError(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("HTTP error: {}", e),
+            ),
+            AppError::HttpBuildError(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to build HTTP response: {}", e),
             ),
             AppError::JsonParseError(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,9 @@ impl AppState {
 /// byte what it was.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn build_router(state: AppState) -> Router {
+    // Before the listener binds, not on the first proxied request.
+    proxy::warm_http_clients();
+
     let cors = tower_http::cors::CorsLayer::new()
         .allow_origin(tower_http::cors::Any)
         .allow_methods(tower_http::cors::Any)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,15 @@
 // of scope for the Nova Guard change. The new Nova Guard modules are clippy-clean
 // under `-D warnings`; allowing these crate-wide avoids churning untouched,
 // logic-heavy pre-existing functions.
+// NOV-132: the crate ships with `panic = "abort"`, so a panic on a request path
+// does not fail one request, it kills the process and drops every in-flight
+// request on that replica. Deny the two ways that happens by accident; each
+// remaining site carries an `#[allow]` with the reason it is safe, so the
+// argument is re-checked on every build instead of living in a comment.
+// `not(test)` keeps the `#[cfg(test)]` modules, where panicking IS the
+// assertion mechanism, unaffected. `src/main.rs` is a separate crate root and
+// is deliberately not covered: startup is where an abort is correct.
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 #![allow(clippy::field_reassign_with_default)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::borrowed_box)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,7 +388,7 @@ async fn print_banner() {
     print!("\n    Starting Noveum AI Gateway ");
     for frame in frames.iter().cycle().take(15) {
         print!("\r    Starting Noveum AI Gateway {}  ", frame.bright_cyan());
-        std::io::Write::flush(&mut std::io::stdout()).unwrap();
+        let _ = std::io::Write::flush(&mut std::io::stdout());
         tokio::time::sleep(Duration::from_millis(120)).await;
     }
     println!("\r    Starting Noveum AI Gateway ✓  \n");
@@ -422,18 +422,31 @@ async fn print_banner() {
 
 async fn shutdown_signal() {
     info!("Registering shutdown signal handler");
+    // A handler that cannot be installed (fd exhaustion) must not abort the
+    // process: the gateway is already serving traffic by the time this runs.
+    // Degrade to a future that never completes, so the other signal still works
+    // and the operator gets a loud line in the log.
     let ctrl_c = async {
-        tokio::signal::ctrl_c()
-            .await
-            .expect("Failed to install CTRL+C signal handler")
+        match tokio::signal::ctrl_c().await {
+            Ok(()) => {}
+            Err(e) => {
+                error!(error = %e, "failed to install the CTRL+C handler; SIGINT will not shut down gracefully");
+                std::future::pending::<()>().await
+            }
+        }
     };
 
     #[cfg(unix)]
     let terminate = async {
-        signal::unix::signal(signal::unix::SignalKind::terminate())
-            .expect("Failed to install signal handler")
-            .recv()
-            .await;
+        match signal::unix::signal(signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => {
+                error!(error = %e, "failed to install the SIGTERM handler; SIGTERM will not shut down gracefully");
+                std::future::pending::<()>().await
+            }
+        }
     };
 
     #[cfg(not(unix))]

--- a/src/policy/config.rs
+++ b/src/policy/config.rs
@@ -266,6 +266,7 @@ fn config_validators() -> &'static HashMap<&'static str, Validator> {
     VALIDATORS.get_or_init(|| {
         // The schema is checked in and covered by `schema_document_is_valid`, so a
         // parse failure here is a build-time bug, not a runtime input problem.
+        #[allow(clippy::expect_used, reason = "compile-time constant: the schema is include_str! and covered by schema_document_is_valid")]
         let schema: serde_json::Value = serde_json::from_str(POLICY_SCHEMA_JSON)
             .expect("embedded novaguard schema is not valid JSON");
         let defs = schema.get("$defs").cloned().unwrap_or_default();

--- a/src/policy/middleware.rs
+++ b/src/policy/middleware.rs
@@ -1069,8 +1069,8 @@ use std::time::Instant;
 
 use crate::policy::remote::{
     select_tenant, GuardTenancy, RemoteConfig, SharedTenancyConfig, TenantId, TenantRejection,
-    TenantResolver, ROUTING_ORG_HEADERS, ROUTING_PROJECT_HEADER, TENANT_CREDENTIAL_HEADER,
-    TENANT_IDLE_TTL,
+    TenantResolver, PLATFORM_CLIENT, ROUTING_ORG_HEADERS, ROUTING_PROJECT_HEADER,
+    TENANT_CREDENTIAL_HEADER, TENANT_IDLE_TTL,
 };
 
 /// One tenant's complete, isolated enforcement runtime.
@@ -1116,6 +1116,12 @@ impl SharedTenancy {
         cost_mode: Option<crate::policy::config::CostEnforcementMode>,
         allow_unguarded_start: bool,
     ) -> Self {
+        // Shared mode fetches nothing at startup, so without this the first
+        // deref of the platform client would be inside `fetch_identity`, on the
+        // first `/v1/*` request. Forcing it here turns a TLS/root-store failure
+        // into a boot abort in shared mode as it already is in dedicated mode,
+        // and does so for library embedders too, not just `main`.
+        once_cell::sync::Lazy::force(&PLATFORM_CLIENT);
         let resolver =
             TenantResolver::new(&cfg.base_url, cfg.resolution_ttl, cfg.max_tenants.max(64));
         Self {

--- a/src/policy/middleware.rs
+++ b/src/policy/middleware.rs
@@ -69,6 +69,10 @@ fn resolve_max_output_tokens(body_json: &Value) -> Result<Option<u64>, &'static 
 }
 
 /// Provider-shaped 400 for an unusable output limit.
+#[allow(
+    clippy::expect_used,
+    reason = "constant status and &'static str headers only, so the builder cannot fail"
+)]
 fn invalid_output_limit_response(key: &str) -> Response {
     let body = serde_json::json!({
         "error": {
@@ -906,6 +910,10 @@ pub use crate::routing::{
 /// response plus the provider's authoritative token counts when the body was
 /// buffered and carried them. `None` usage means the caller must not claim to
 /// know what this call consumed.
+#[allow(
+    clippy::expect_used,
+    reason = "the 502 envelope uses a constant status and &'static str headers only"
+)]
 async fn enforce_output(
     engine: &PolicyEngine,
     provider: &str,
@@ -1278,10 +1286,7 @@ impl SharedTenancy {
 
     /// How many tenants are currently warm (diagnostics/tests).
     pub fn warm_tenants(&self) -> usize {
-        self.slots
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .len()
+        self.slots.lock().unwrap_or_else(|e| e.into_inner()).len()
     }
 }
 
@@ -1340,6 +1345,10 @@ pub async fn tenant_middleware(
 }
 
 /// Provider-shaped error envelope for a tenancy refusal.
+#[allow(
+    clippy::expect_used,
+    reason = "status goes through from_u16(..).unwrap_or(..) and headers are &'static str, so the builder cannot fail"
+)]
 pub fn tenant_rejection_response(rejection: &TenantRejection) -> Response {
     let body = serde_json::json!({
         "error": {

--- a/src/policy/middleware.rs
+++ b/src/policy/middleware.rs
@@ -150,10 +150,10 @@ pub async fn guard_middleware(
             // Body too large or unreadable; we cannot inspect it. Fail open by
             // forwarding the original (already-consumed) request is impossible,
             // so respond with a clear error rather than silently dropping.
-            return Response::builder()
-                .status(axum::http::StatusCode::PAYLOAD_TOO_LARGE)
-                .body(Body::from("request body exceeds gateway inspection limit"))
-                .unwrap();
+            let mut too_large =
+                Response::new(Body::from("request body exceeds gateway inspection limit"));
+            *too_large.status_mut() = axum::http::StatusCode::PAYLOAD_TOO_LARGE;
+            return too_large;
         }
     };
 

--- a/src/policy/middleware.rs
+++ b/src/policy/middleware.rs
@@ -1232,7 +1232,7 @@ impl SharedTenancy {
     }
 
     fn slot(&self, tenant: &TenantId) -> Arc<TenantSlot> {
-        let mut slots = self.slots.lock().expect("tenant registry lock poisoned");
+        let mut slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(slot) = slots.get(tenant) {
             return slot.clone();
         }
@@ -1253,7 +1253,7 @@ impl SharedTenancy {
         // Collect the drop set under the lock, then release it before dropping
         // the runtimes (each drop touches a queue and a task handle).
         let doomed = {
-            let mut slots = self.slots.lock().expect("tenant registry lock poisoned");
+            let mut slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
             let snapshot: Vec<(TenantId, u64)> = slots
                 .iter()
                 .map(|(t, s)| (t.clone(), s.last_used.load(Ordering::Relaxed)))
@@ -1280,7 +1280,7 @@ impl SharedTenancy {
     pub fn warm_tenants(&self) -> usize {
         self.slots
             .lock()
-            .expect("tenant registry lock poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .len()
     }
 }

--- a/src/policy/platform.rs
+++ b/src/policy/platform.rs
@@ -39,9 +39,8 @@ fn map_action(_action: &str) -> &'static str {
 /// Lowercase the `action` enum(s) inside a platform policy config so it parses as
 /// the gateway's `PolicyAction`. All other fields already line up.
 fn normalize_config(policy_type: &str, mut config: Value) -> Value {
-    if config.get("action").and_then(|a| a.as_str()).is_some() {
-        let a = config["action"].as_str().unwrap();
-        config["action"] = json!(map_action(a));
+    if let Some(action) = config.get("action").and_then(|a| a.as_str()) {
+        config["action"] = json!(map_action(action));
     }
     if policy_type == "cost_cap" {
         // `enforcementMode` selects platform-atomic admission (`strict`) over the

--- a/src/policy/remote.rs
+++ b/src/policy/remote.rs
@@ -1368,13 +1368,15 @@ impl PendingInner {
     }
 
     fn prune(&mut self) {
-        while let Some(front) = self.completed.front() {
-            if front.at.elapsed() >= PENDING_SPEND_TTL {
-                let e = self.completed.pop_front().expect("front just checked");
-                Self::subtract(&mut self.totals, &e);
-            } else {
+        while self
+            .completed
+            .front()
+            .is_some_and(|front| front.at.elapsed() >= PENDING_SPEND_TTL)
+        {
+            let Some(e) = self.completed.pop_front() else {
                 break;
-            }
+            };
+            Self::subtract(&mut self.totals, &e);
         }
         // Backstop: reap active entries whose guard never fired. `active` is
         // bounded by in-flight concurrency, so the scan is cheap.

--- a/src/policy/remote.rs
+++ b/src/policy/remote.rs
@@ -24,6 +24,10 @@ use crate::policy::rules::LiveState;
 /// (which forces HTTP/2 prior knowledge for HTTPS provider calls), this
 /// negotiates the HTTP version normally so it works against a plain HTTP/1.1
 /// control plane (e.g. a local `http://localhost:3000`) as well as HTTPS.
+#[allow(
+    clippy::expect_used,
+    reason = "startup: forced by bootstrap_engine (dedicated) and SharedTenancy::new (shared)"
+)]
 pub(crate) static PLATFORM_CLIENT: Lazy<reqwest::Client> = Lazy::new(|| {
     reqwest::Client::builder()
         .use_rustls_tls()

--- a/src/policy/remote.rs
+++ b/src/policy/remote.rs
@@ -906,7 +906,7 @@ impl TenantResolver {
     }
 
     fn slot(&self, fingerprint: &str) -> Arc<ResolverSlot> {
-        let mut slots = self.slots.lock().expect("tenant resolver lock poisoned");
+        let mut slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(slot) = slots.get(fingerprint) {
             return slot.clone();
         }
@@ -1409,7 +1409,7 @@ impl PendingSpend {
     /// the totals of every *other* un-expired reservation, to be folded into
     /// the counters the policy engine evaluates.
     pub fn reserve(&self, cost_usd: f64, tokens: u64) -> (u64, PendingTotals) {
-        let mut inner = self.inner.lock().expect("pending-spend lock poisoned");
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         inner.prune();
         let others = inner.totals;
         let id = inner.next_id;
@@ -1429,7 +1429,7 @@ impl PendingSpend {
     /// Release a reservation whose request was NOT forwarded (blocked): it
     /// will consume nothing, so it must stop counting immediately.
     pub fn release(&self, reservation: u64) {
-        let mut inner = self.inner.lock().expect("pending-spend lock poisoned");
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(idx) = inner.active.iter().position(|e| e.id == reservation) {
             let e = inner.active.swap_remove(idx);
             let mut t = inner.totals;
@@ -1445,7 +1445,7 @@ impl PendingSpend {
     /// for [`PENDING_SPEND_TTL`] from NOW (covering the usage-report + state
     /// ingestion lag), then expires.
     pub fn complete(&self, reservation: u64) {
-        let mut inner = self.inner.lock().expect("pending-spend lock poisoned");
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(idx) = inner.active.iter().position(|e| e.id == reservation) {
             let mut e = inner.active.swap_remove(idx);
             e.at = Instant::now();
@@ -1459,13 +1459,13 @@ impl PendingSpend {
     /// cancellation tests assert on this rather than on the totals (a
     /// *completed* entry legitimately keeps counting for its short TTL).
     pub fn active_count(&self) -> usize {
-        let inner = self.inner.lock().expect("pending-spend lock poisoned");
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         inner.active.len()
     }
 
     /// Current un-expired pending totals (prunes expired entries).
     pub fn sum(&self) -> PendingTotals {
-        let mut inner = self.inner.lock().expect("pending-spend lock poisoned");
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         inner.prune();
         inner.totals
     }

--- a/src/policy/synthetic.rs
+++ b/src/policy/synthetic.rs
@@ -25,8 +25,8 @@ use uuid::Uuid;
 #[cfg(not(target_arch = "wasm32"))]
 use axum::{
     body::Body,
-    http::{header, StatusCode},
-    response::Response,
+    http::{header, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
 };
 
 /// How a block should be surfaced to the caller.
@@ -110,15 +110,22 @@ pub fn block_response(
     let body = block_body(provider, model, decision, mode);
     let status =
         StatusCode::from_u16(block_status(mode)).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-    let policy_header = policy_header_token(&decision.policy_id);
-
-    Response::builder()
+    let mut response = Response::builder()
         .status(status)
         .header(header::CONTENT_TYPE, "application/json")
         .header("x-noveum-guard-blocked", "true")
-        .header("x-noveum-guard-policy", policy_header)
         .body(Body::from(serde_json::to_vec(&body).unwrap_or_default()))
-        .expect("synthetic response with sanitized header is always valid")
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+
+    // `policy_id` is arbitrary platform JSON. `policy_header_token` sanitizes it
+    // to ASCII-graphic, but that invariant lives sixty lines away with no
+    // compiler-visible link to this call. Going through `HeaderValue` means a
+    // future edit to the sanitizer drops the header instead of aborting the
+    // process on the blocked-request path.
+    if let Ok(v) = HeaderValue::from_str(&policy_header_token(&decision.policy_id)) {
+        response.headers_mut().insert("x-noveum-guard-policy", v);
+    }
+    response
 }
 
 fn reason_text(decision: &PolicyDecision) -> String {
@@ -297,6 +304,37 @@ mod tests {
         );
         let b = body_json(resp).await;
         assert_eq!(b["error"]["type"], "permission_error");
+    }
+
+    /// A hostile `policy_id` must never abort the process. Under
+    /// `panic = "abort"` a bad header value here would kill the replica on the
+    /// blocked-request path, which is exactly when a misconfigured or hostile
+    /// tenant is most active.
+    #[tokio::test]
+    async fn a_hostile_policy_id_never_panics_and_yields_a_valid_header() {
+        for hostile in [
+            "pol\r\nX-Injected: yes",
+            "pol\u{0}nul",
+            "policy\u{7f}del",
+            "\u{1f4a5}\u{1f4a5}",
+            "",
+            &"x".repeat(4096),
+        ] {
+            let mut d = decision();
+            d.policy_id = hostile.to_string();
+            let resp = block_response("openai", "gpt-4o", &d, BlockResponseMode::SyntheticSuccess);
+            assert_eq!(resp.status(), StatusCode::OK);
+            if let Some(v) = resp.headers().get("x-noveum-guard-policy") {
+                assert!(
+                    v.to_str().is_ok(),
+                    "emitted header must be representable: {hostile:?}"
+                );
+                assert!(
+                    !v.as_bytes().iter().any(|b| *b < 0x21 || *b > 0x7e),
+                    "emitted header must stay ASCII-graphic: {hostile:?}"
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -560,7 +560,7 @@ impl Provider for BedrockProvider {
                 builder = builder.header("x-request-id", id);
             }
 
-            Ok(builder.body(Body::from_stream(stream)).unwrap())
+            Ok(builder.body(Body::from_stream(stream))?)
         } else {
             // For non-streaming responses, transform the body to OpenAI format
             debug!("Processing Bedrock non-streaming response");

--- a/src/proxy/client.rs
+++ b/src/proxy/client.rs
@@ -84,6 +84,16 @@ fn is_bedrock_runtime_host(host: &str) -> bool {
         .is_some_and(|rest| rest.ends_with(".amazonaws.com"))
 }
 
+/// Build both clients now, so a broken TLS backend or an unreadable root
+/// certificate store aborts the process at startup instead of on the first
+/// proxied request. Both are `Lazy`, and their builders `.expect(..)`; under
+/// `panic = "abort"` a first-request failure would kill the replica after it had
+/// already passed its readiness probe.
+pub fn warm() {
+    Lazy::force(&CLIENT);
+    Lazy::force(&NEGOTIATING_CLIENT);
+}
+
 /// Pick the right client for an upstream URL: h2-prior-knowledge for the known
 /// first-party provider hosts, a normally-negotiating client for everything
 /// else (cleartext mocks, custom/overridden endpoints, non-Bedrock AWS hosts).

--- a/src/proxy/client.rs
+++ b/src/proxy/client.rs
@@ -19,6 +19,10 @@ fn base_builder(config: &AppConfig) -> reqwest::ClientBuilder {
         .brotli(true)
 }
 
+#[allow(
+    clippy::expect_used,
+    reason = "startup: warm() forces this before the listener binds, so a broken TLS stack fails the rollout"
+)]
 pub fn create_client(config: &AppConfig) -> reqwest::Client {
     info!("Creating HTTP client with optimized settings");
 
@@ -42,6 +46,10 @@ pub static CLIENT: Lazy<reqwest::Client> = Lazy::new(|| {
 /// `http://` upstream (local mock provider, self-hosted gateway) or a custom
 /// HTTPS endpoint behind an HTTP/1.1-only proxy would fail with an opaque h2
 /// error before the request ever reached the provider.
+#[allow(
+    clippy::expect_used,
+    reason = "startup: warm() forces this before the listener binds, so a broken TLS stack fails the rollout"
+)]
 pub static NEGOTIATING_CLIENT: Lazy<reqwest::Client> = Lazy::new(|| {
     let config = AppConfig::new();
     base_builder(&config)

--- a/src/proxy/client.rs
+++ b/src/proxy/client.rs
@@ -86,7 +86,7 @@ fn is_bedrock_runtime_host(host: &str) -> bool {
 
 /// Build both clients now, so a broken TLS backend or an unreadable root
 /// certificate store aborts the process at startup instead of on the first
-/// proxied request. Both are `Lazy`, and their builders `.expect(..)`; under
+/// proxied request. Both are `Lazy`, and their builders panic on failure; under
 /// `panic = "abort"` a first-request failure would kill the replica after it had
 /// already passed its readiness probe.
 pub fn warm() {

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -12,6 +12,7 @@ use tracing::{debug, error};
 use crate::{config::AppConfig, error::AppError, providers::create_provider};
 
 mod client;
+pub use client::warm as warm_http_clients;
 pub use client::CLIENT;
 mod signing;
 

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -139,7 +139,7 @@ async fn process_response(
         })
     {
         let body = response.bytes().await?;
-        return Ok(response_builder.body(Body::from(body)).unwrap());
+        return Ok(response_builder.body(Body::from(body))?);
     }
 
     // Optimized streaming response handling
@@ -161,5 +161,5 @@ async fn process_response(
         .header("transfer-encoding", "chunked")
         .header("x-accel-buffering", "no");
 
-    Ok(response_builder.body(Body::from_stream(stream)).unwrap())
+    Ok(response_builder.body(Body::from_stream(stream))?)
 }

--- a/src/proxy/signing.rs
+++ b/src/proxy/signing.rs
@@ -53,8 +53,7 @@ pub async fn sign_aws_request(
         .method(method)
         .uri(url)
         .header("Content-Type", "application/json")
-        .body(())
-        .unwrap();
+        .body(())?;
 
     // Apply signing instructions
     signing_instructions.apply_to_request_http1x(&mut temp_request);

--- a/src/sigv4.rs
+++ b/src/sigv4.rs
@@ -16,6 +16,10 @@ use sha2::{Digest, Sha256};
 
 type HmacSha256 = Hmac<Sha256>;
 
+#[allow(
+    clippy::expect_used,
+    reason = "HMAC accepts any key length; InvalidLength is unreachable for this MAC"
+)]
 fn hmac(key: &[u8], data: &[u8]) -> Vec<u8> {
     let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
     mac.update(data);

--- a/src/telemetry/middleware.rs
+++ b/src/telemetry/middleware.rs
@@ -90,39 +90,30 @@ pub async fn metrics_middleware(
     // Get metrics extractor for this provider
     let metrics_extractor = get_metrics_extractor(&provider);
 
-    // Store original values before consuming request
-    let original_method = req.method().clone();
-    let original_uri = req.uri().clone();
-    let original_headers = req.headers().clone();
+    // Split the request so the body can be buffered and the head reused
+    // verbatim. Rebuilding through `Request::builder()` re-parses the method and
+    // URI (fallible, and previously `.unwrap()`ed) and silently drops
+    // `extensions` and `version`; `from_parts` is infallible and keeps both.
+    let (req_parts, req_body_in) = req.into_parts();
 
-    // Extract and store the original request body
     let (req_size, req_body, body) = {
-        let bytes = to_bytes(req.into_body(), usize::MAX)
-            .await
-            .unwrap_or_default();
+        let bytes = to_bytes(req_body_in, usize::MAX).await.unwrap_or_default();
         let size = bytes.len();
         let req_body = serde_json::from_slice(&bytes).ok();
         debug!("Request body size: {} bytes", size);
         (size, req_body, Body::from(bytes))
     };
 
-    // Reconstruct request with original values
-    let mut new_req = Request::builder()
-        .method(original_method)
-        .uri(original_uri)
-        .body(body)
-        .unwrap();
-    *new_req.headers_mut() = original_headers;
+    let new_req = Request::from_parts(req_parts, body);
 
     // Process the response with a timeout
     let response = tokio::time::timeout(Duration::from_secs(30), next.run(new_req))
         .await
         .unwrap_or_else(|_| {
             debug!("Request timed out after 30 seconds");
-            Response::builder()
-                .status(http::StatusCode::GATEWAY_TIMEOUT)
-                .body(Body::from("Request timed out after 30 seconds"))
-                .unwrap()
+            let mut timed_out = Response::new(Body::from("Request timed out after 30 seconds"));
+            *timed_out.status_mut() = http::StatusCode::GATEWAY_TIMEOUT;
+            timed_out
         });
 
     let is_streaming = response

--- a/src/telemetry/middleware.rs
+++ b/src/telemetry/middleware.rs
@@ -92,7 +92,7 @@ pub async fn metrics_middleware(
 
     // Split the request so the body can be buffered and the head reused
     // verbatim. Rebuilding through `Request::builder()` re-parses the method and
-    // URI (fallible, and previously `.unwrap()`ed) and silently drops
+    // URI (fallible, and previously unwrapped) and silently drops
     // `extensions` and `version`; `from_parts` is infallible and keeps both.
     let (req_parts, req_body_in) = req.into_parts();
 

--- a/src/worker_rt.rs
+++ b/src/worker_rt.rs
@@ -913,7 +913,12 @@ async fn proxy(
         url = "https://api.anthropic.com/v1/messages".to_string();
         forward_bytes = forward_body_bytes(body_rewritten, &body_json, &body_bytes);
     } else {
-        let route = route.expect("checked above");
+        // Guarded at the top of the handler, which 400s unless one of
+        // `route`/`is_anthropic`/`is_bedrock` holds. Binding it here makes that
+        // structural instead of an argument a future edit could invalidate.
+        let Some(route) = route else {
+            return Response::error("Unsupported or not-yet-ported provider on edge", 400);
+        };
         out_headers = copy_headers_excluding(req.headers(), REQUEST_SKIP_HEADERS)?;
         // `OPENAI_BASE_URL` targets a compatible upstream, the same override the
         // native gateway honors. Scoped to `x-provider: openai` for the same


### PR DESCRIPTION
Removes every panicking call reachable from a request path, and adds a clippy deny so new ones cannot land.