### PR TITLE
chore(release): harden and document v2.0.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,18 @@
-target/
-.git/
-.github/
-.env
-**/*.rs.bk
-Dockerfile
-.dockerignore
-.gitignore
-README.md
-*.log 
+# Deny the entire repository by default. The release image needs only the
+# manifest/lockfile plus the source and compile-time data directories copied by
+# Dockerfile. This prevents local .env files, Wrangler state, credentials,
+# generated bundles, logs, and unrelated working-tree files from being sent to
+# a local or remote BuildKit daemon.
+**
+
+!Cargo.toml
+!Cargo.lock
+
+!src/
+!src/**
+
+!schema/
+!schema/**
+
+!pricing/
+!pricing/**

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,8 +14,6 @@ env:
 
 jobs:
   docker:
-    # Skip this job if it's a push event on a non-main branch
-    if: github.event_name != 'push' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,7 +23,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Validate workflow release and secret-ref guards
+        run: bash scripts/validate_docker_release.sh workflows
 
       # Generate Cargo.lock if it doesn't exist
       - name: Generate Cargo.lock
@@ -37,30 +39,64 @@ jobs:
       - name: Extract version from Cargo.toml
         id: version
         run: |
-          VERSION=$(awk -F '"' '/^version = / {print $2}' Cargo.toml)
-          echo "CARGO_VERSION=${VERSION}" >> $GITHUB_ENV
+          set -euo pipefail
+          VERSION="$(bash scripts/validate_docker_release.sh package-version)"
+          echo "CARGO_VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "Version found: ${VERSION}"
+
+      - name: Select build-only or immutable release mode
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          MODE="$(bash scripts/validate_docker_release.sh mode "${EVENT_NAME}" "${GIT_REF}")"
+          if [[ "${MODE}" == "release" ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Docker workflow mode: ${MODE}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      # Always build to verify Dockerfile, but push only on main
-      - name: Build Docker image (non-main branch)
-        if: github.ref != 'refs/heads/main'
+      - name: Prove the Docker context excludes local secrets and state
+        run: bash scripts/validate_docker_release.sh context
+
+      # Every event builds and runs the exact image before any registry login.
+      # Pull requests, main pushes, and manual runs never publish it.
+      - name: Build Docker image for runtime verification
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: false
+          tags: noveum-ai-gateway:ci-${{ github.sha }}
           # Match local build platform for consistency
           platforms: linux/amd64
+          build-args: |
+            VERSION=${{ env.CARGO_VERSION }}
+            REVISION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Add load flag to ensure it can be tested locally
           load: true
 
-      # Main branch handling - build and push
+      - name: Validate the hardened runtime image
+        run: bash scripts/validate_docker_release.sh runtime-image "noveum-ai-gateway:ci-${{ github.sha }}" "${{ github.sha }}"
+
+      # A versioned image is published only for an exact v${Cargo version} tag.
+      # It must also point to a commit already contained in trusted main.
+      - name: Verify release commit provenance against main
+        if: steps.release.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          bash scripts/validate_docker_release.sh provenance HEAD refs/remotes/origin/main
+
       - name: Log in to GitHub Container Registry
-        if: github.ref == 'refs/heads/main'
+        if: steps.release.outputs.publish == 'true'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -68,7 +104,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata for GHCR
-        if: github.ref == 'refs/heads/main'
+        if: steps.release.outputs.publish == 'true'
         id: meta-ghcr
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
@@ -78,27 +114,30 @@ jobs:
             type=raw,value=${{ env.CARGO_VERSION }}
 
       - name: Build and push to GitHub Container Registry
-        if: github.ref == 'refs/heads/main'
+        if: steps.release.outputs.publish == 'true'
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: true
           tags: ${{ steps.meta-ghcr.outputs.tags }}
           labels: ${{ steps.meta-ghcr.outputs.labels }}
+          build-args: |
+            VERSION=${{ env.CARGO_VERSION }}
+            REVISION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Match local build platform for GHCR build too
           platforms: linux/amd64
 
       - name: Login to Docker Hub
-        if: github.ref == 'refs/heads/main'
+        if: steps.release.outputs.publish == 'true'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push to Docker Hub
-        if: github.ref == 'refs/heads/main'
+        if: steps.release.outputs.publish == 'true'
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
@@ -106,6 +145,9 @@ jobs:
           tags: |
             noveum/noveum-ai-gateway:latest
             noveum/noveum-ai-gateway:${{ env.CARGO_VERSION }}
+          build-args: |
+            VERSION=${{ env.CARGO_VERSION }}
+            REVISION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64

--- a/.github/workflows/provider-smoke.yml
+++ b/.github/workflows/provider-smoke.yml
@@ -22,6 +22,9 @@ permissions:
 jobs:
   smoke:
     name: Live provider integration tests
+    # Repository/provider secrets are available only to reviewed main code.
+    # A manual dispatch from any other selected ref is skipped before checkout.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -83,10 +86,17 @@ jobs:
           HOST: 127.0.0.1
           PORT: "3000"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_TEST_MODEL: ${{ vars.OPENAI_TEST_MODEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_TEST_MODEL: ${{ vars.ANTHROPIC_TEST_MODEL }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GROQ_TEST_MODEL: ${{ vars.GROQ_TEST_MODEL }}
           TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+          TOGETHER_TEST_MODEL: ${{ vars.TOGETHER_TEST_MODEL }}
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+          FIREWORKS_TEST_MODEL: ${{ vars.FIREWORKS_TEST_MODEL }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+          BEDROCK_TEST_MODEL: ${{ vars.BEDROCK_TEST_MODEL }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
       # Run the hermetic suites by name rather than `cargo test`, which would
       # also run the live-provider cases in `run_integration_tests`; those need
       # real keys and belong in the scheduled smoke workflow. The filtered step
-      # below runs only that target's seven network-free helper regressions.
+      # below runs only that target's eight network-free helper regressions.
       - name: Unit tests
         run: |
           cargo test --lib
@@ -119,15 +119,10 @@ jobs:
           cargo install cargo-deny --version "${CARGO_DENY_VERSION}" --locked
 
       # `--deny warnings` is what stops this from silently passing: cargo-audit
-      # exits 0 on unmaintained/unsound findings by default. The two `--ignore`
-      # IDs are the waivers documented in deny.toml — deny.toml is the source of
-      # truth for *why* they are waived, and the two lists must stay in sync.
-      # Any advisory that is not one of those two fails the job.
+      # exits 0 on unmaintained/unsound findings by default. There are no
+      # advisory exemptions; any finding fails the job.
       - name: cargo audit
-        run: |
-          cargo audit --deny warnings \
-            --ignore RUSTSEC-2021-0141 \
-            --ignore RUSTSEC-2023-0086
+        run: cargo audit --deny warnings
 
       # All four checks run explicitly rather than relying on defaults, so
       # dropping one has to be a visible edit to this file.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,14 +53,17 @@ jobs:
       # Run the hermetic suites by name rather than `cargo test`, which would
       # also run the live-provider cases in `run_integration_tests`; those need
       # real keys and belong in the scheduled smoke workflow. The filtered step
-      # below runs only that target's three network-free helper regressions.
+      # below runs only that target's seven network-free helper regressions.
       - name: Unit tests
-        run: cargo test --lib
+        run: |
+          cargo test --lib
+          cargo test --bin noveum-ai-gateway runtime_uses_the_configured_worker_thread_count
 
       - name: Provider harness helper tests (no live calls)
         run: |
           cargo test --test run_integration_tests streaming_smoke_
           cargo test --test run_integration_tests request_body_can_select_
+          cargo test --test run_integration_tests model_override_
 
       - name: Nova Guard platform integration tests
         run: cargo test --test novaguard_platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cloudflare Worker Bedrock requests with `stream: true` now fail with a
   deterministic OpenAI-shaped HTTP 400 with
-  `error.code = "unsupported_feature"` before Nova Guard admission or AWS dispatch. Native
+  `error.code = "unsupported_feature"` before Nova Guard admission or AWS
+  dispatch. A present non-Boolean `stream` value is likewise rejected with a
+  deterministic HTTP 400 instead of being treated as buffered mode. Native
   Bedrock ConverseStream remains supported; Worker Bedrock streaming is not
   implemented and is no longer allowed to enter an invalid signing/response
   path.
@@ -63,14 +65,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   require authoritative terminal streaming usage. OpenAI and Groq request that
   usage explicitly; Together and Fireworks rely on their provider-emitted final
   chunks rather than an undocumented OpenAI option.
+- Native Bedrock event-stream decoding now uses AWS's maintained Smithy parser,
+  validates both frame checksums before translating a message to SSE, and
+  propagates corrupt-frame failures to the downstream body. This removes the
+  legacy parser chain that pulled in the unsound `lexical-core 0.7.6`.
+- Native and integration-test environment loading now uses the maintained
+  `dotenvy` fork instead of the unmaintained `dotenv 0.15.0`. Together with the
+  Bedrock parser migration, the Rust security gates now carry no explicit
+  advisory waivers.
 - The integration harness no longer falls back to the repository's production
-  `.env` when `.env.test` is absent. Hermetic CI now runs all seven network-free
+  `.env` when `.env.test` is absent. Hermetic CI now runs all eight network-free
   provider-helper regressions, including model override and provider-aware
   terminal-usage selection.
 - The Workerd suite now verifies `HEAD /` parity, cross-provider credential
-  stripping, and the complete OpenAI-shaped Worker Bedrock
-  `unsupported_feature` error envelope rather than checking only its status or
-  one field.
+  stripping, the complete OpenAI-shaped Worker Bedrock `unsupported_feature`
+  error envelope, and rejection of a non-Boolean Bedrock `stream` field rather
+  than checking only a status or one field.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-08-24
+
+### Added
+
+- Added a static, no-JavaScript landing page at `GET /` and `HEAD /` for native
+  and Cloudflare runtimes. It reports the runtime and package version, links to
+  health and public project resources, sends a restrictive content-security
+  policy, and is cached for five minutes. `HEAD` preserves the response contract
+  without a body. `/docs` and `/openapi.json` remain unimplemented.
+- Native Bedrock signing now accepts the optional `x-aws-session-token` header,
+  bringing temporary STS credential support to both native and Cloudflare
+  runtimes.
+
+### Fixed
+
+- Cloudflare Worker Bedrock requests with `stream: true` now fail with a
+  deterministic OpenAI-shaped HTTP 400 with
+  `error.code = "unsupported_feature"` before Nova Guard admission or AWS dispatch. Native
+  Bedrock ConverseStream remains supported; Worker Bedrock streaming is not
+  implemented and is no longer allowed to enter an invalid signing/response
+  path.
+- The native server now honors the configured `HOST` when binding its TCP
+  listener. The previous startup path logged `HOST` but always bound the
+  wildcard address.
+- `WORKER_THREADS` now determines the native Tokio runtime's worker count; the
+  previous startup path applied the value only after Tokio had already created
+  its runtime.
+- The container image now sets `HOST=0.0.0.0` so published ports and
+  orchestrator probes can reach the process, while native installations retain
+  the loopback default. Release builds pass the Cargo version into the OCI
+  image label instead of permanently labeling the image `latest`, record the
+  exact source revision, and run as the fixed unprivileged UID/GID
+  `65532:65532`.
+- Container automation now publishes versioned GHCR and Docker Hub images (and
+  advances `latest`) only for a pushed `v${Cargo package version}` tag. Pull
+  requests, `main`, and manual runs build without publishing; a mismatched tag
+  or a tag whose commit is outside trusted `main` fails before registry login.
+  Every event validates the image with a read-only root filesystem, all
+  capabilities dropped, `no-new-privileges`, the exact OCI labels, and a live
+  versioned health response. The BuildKit context is deny-by-default and
+  contains only the Cargo manifests, Rust source, policy schema, and pricing
+  catalog.
+- Cross-provider credential headers are stripped from generic upstream
+  requests. `x-api-key` is reconstructed only for Anthropic, and `x-aws-*`
+  headers are consumed only by Bedrock, so a credential for one provider is not
+  leaked to another provider.
+- Cloudflare version and alias preview URLs are explicitly disabled in
+  `wrangler.toml`. This keeps preview hostnames dark after the deleted-version
+  routing incident and makes future preview exposure an intentional,
+  reviewable configuration change.
+- Live-provider smoke defaults now use the model IDs verified on 2026-08-24,
+  accept per-provider model overrides through repository/environment variables,
+  can pass an optional AWS STS session token without storing it in source, and
+  require authoritative terminal streaming usage. OpenAI and Groq request that
+  usage explicitly; Together and Fireworks rely on their provider-emitted final
+  chunks rather than an undocumented OpenAI option.
+- The integration harness no longer falls back to the repository's production
+  `.env` when `.env.test` is absent. Hermetic CI now runs all seven network-free
+  provider-helper regressions, including model override and provider-aware
+  terminal-usage selection.
+- The Workerd suite now verifies `HEAD /` parity, cross-provider credential
+  stripping, and the complete OpenAI-shaped Worker Bedrock
+  `unsupported_feature` error envelope rather than checking only its status or
+  one field.
+
+### Documentation
+
+- Added a v1.2-to-v2 migration guide, a five-minute quick start, an explicit
+  credential/scope matrix, production deployment and rollback runbooks, and a
+  repeatable native/Worker/live-provider validation checklist.
+- Made the packaged README's repository links resolve through the immutable
+  `v2.0.1` Git tag instead of crates.io's moving `HEAD` rewrite.
+- Preserved the v2.0.0 Cloudflare deployment as a dated release baseline and
+  clarified, without pinning the current production version, that a shared
+  hostname must remain transparent unless it is split into dedicated
+  project-bound deployments.
+- Replaced stale Fireworks and Together model inventories with dated,
+  production-verified examples and documented the native/Worker Bedrock
+  streaming split and AWS credential boundary.
+
 ## [2.0.0] - 2026-08-24
 
 ### Breaking changes
@@ -21,9 +101,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gateway can preserve and report an invalid wire-level policy name. Use
   `Policy::kind()` to read its parsed `PolicyType` and `Policy::type_name()` to
   read the original string.
-- `PolicyEngine::from_env` is now synchronous and returns `Result<Self,
+- `PolicyEngine::from_env` remains asynchronous but now returns `Result<Self,
   String>` so malformed or unsupported configuration fails explicitly instead
-  of producing an apparently valid engine.
+  of producing an apparently valid engine. Callers must continue to `.await`
+  it and now handle the error.
 
 ### Added
 
@@ -277,10 +358,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error handling
 - Basic documentation
 
-[Unreleased]: https://github.com/Noveum/ai-gateway/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/Noveum/ai-gateway/compare/v2.0.1...main
+[2.0.1]: https://github.com/Noveum/ai-gateway/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Noveum/ai-gateway/compare/v1.2.0...v2.0.0
-[1.2.0]: https://github.com/Noveum/ai-gateway/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/Noveum/ai-gateway/compare/v1.0.1...v1.1.0
+[1.2.0]: https://github.com/Noveum/ai-gateway/compare/65f678294a0609dcd1482bf2b1b9b830dcde42c5...v1.2.0
+[1.1.0]: https://github.com/Noveum/ai-gateway/compare/v1.0.1...65f678294a0609dcd1482bf2b1b9b830dcde42c5
 [1.0.1]: https://github.com/noveum/ai-gateway/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/noveum/ai-gateway/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/noveum/ai-gateway/compare/v0.1.7...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "noveum-ai-gateway"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aho-corasick",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,12 +77,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +189,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -265,21 +270,6 @@ dependencies = [
  "ryu",
  "serde",
  "time",
-]
-
-[[package]]
-name = "aws_event_stream_parser"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895663380ac0ff4abb2731941f629c103eef84ffbe6d0309b6cf2c9d1aecf358"
-dependencies = [
- "byteorder",
- "bytes",
- "chrono",
- "crc",
- "nom",
- "tokio-util",
- "uuid 0.8.2",
 ]
 
 [[package]]
@@ -370,12 +360,6 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -437,12 +421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,12 +431,6 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -595,15 +567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,10 +668,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
@@ -1405,19 +1368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,17 +1455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
 name = "noveum-ai-gateway"
 version = "2.0.1"
 dependencies = [
@@ -1525,12 +1464,13 @@ dependencies = [
  "async-trait",
  "aws-credential-types",
  "aws-sigv4",
- "aws_event_stream_parser",
+ "aws-smithy-eventstream",
+ "aws-smithy-types",
  "axum",
  "bytes",
  "chrono",
  "colored",
- "dotenv",
+ "dotenvy",
  "futures",
  "futures-util",
  "hmac 0.12.1",
@@ -1555,7 +1495,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "uuid 1.24.0",
+ "uuid",
  "wiremock",
  "worker",
 ]
@@ -1875,7 +1815,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2228,12 +2168,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,7 +2421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.13.1",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2637,12 +2571,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noveum-ai-gateway"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.94.1"
 description = "A high-performance AI Gateway proxy for routing requests to various AI providers, offering seamless integration and management of multiple AI providers."
@@ -13,7 +13,12 @@ readme = "README.md"
 keywords = ["ai", "gateway", "proxy", "openai", "llm"]
 categories = ["web-programming", "api-bindings", "asynchronous"]
 exclude = [
-    ".env",
+    ".env*",
+    "**/.env*",
+    ".dev.vars*",
+    "**/.dev.vars*",
+    ".wrangler/**/*",
+    "**/.wrangler/**/*",
     ".claude/**/*",
     ".cursorrules",
     ".github/**/*",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,12 +117,13 @@ hyper = { version = "0.14", features = ["client", "runtime"] }
 tower-http = { version = "0.6.2", features = ["cors", "compression-full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 reqwest = { version = "0.12.9", features = ["stream", "json", "rustls-tls", "http2", "gzip", "brotli"], default-features = false }
-dotenv = "0.15"
+dotenvy = "0.15.7"
 async-trait = "0.1"
 num_cpus = "1.15"
 aws-sigv4 = "1.2.5"
 aws-credential-types = "1.2.1"
-aws_event_stream_parser = "0.1.2"
+aws-smithy-eventstream = "0.61.2"
+aws-smithy-types = "1.6.2"
 parking_lot = "0.12"
 colored = "2.1.0"
 tiktoken-rs = "0.12"           # token counting (native); wasm uses a char heuristic
@@ -143,7 +144,7 @@ uuid = { version = "1.15.1", features = ["js"] }   # v4 randomness on wasm
 [dev-dependencies]
 noveum-ai-gateway = { path = "." }
 uuid = { version = "1.15.1", features = ["serde", "v4"] }
-dotenv = "0.15"
+dotenvy = "0.15.7"
 tokio = { version = "1.0", features = ["full", "test-util"] }
 reqwest = { version = "0.12.9", features = ["stream", "json", "rustls-tls", "http2", "gzip", "brotli"], default-features = false }
 serde_json = "1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,12 @@ RUN RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --target x86
 FROM --platform=linux/amd64 debian:bookworm-slim
 
 # Add LABEL to identify the image
+ARG VERSION=dev
+ARG REVISION=unknown
 LABEL org.opencontainers.image.source="https://github.com/noveum/ai-gateway"
 LABEL org.opencontainers.image.description="Noveum AI Gateway"
-LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.revision=$REVISION
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
@@ -52,6 +55,16 @@ RUN apt-get update && apt-get install -y \
 
 # Copy the binary from builder
 COPY --from=builder /usr/src/app/target/x86_64-unknown-linux-gnu/release/noveum-ai-gateway /usr/local/bin/
+
+# Native installations default to loopback for safety. Containers must listen
+# on every container interface so published ports and orchestrator probes can
+# reach the process; operators can still override HOST at runtime.
+ENV HOST=0.0.0.0
+
+# The gateway needs no filesystem writes or privileged port. A fixed numeric
+# identity also works in minimal images without requiring passwd/group entries.
+# Any mounted policy or configuration files must be readable by this identity.
+USER 65532:65532
 
 # Set the startup command
 CMD ["noveum-ai-gateway"]

--- a/README.md
+++ b/README.md
@@ -2,914 +2,358 @@
 
 # Noveum AI Gateway
 
-🚀 The world's fastest AI Gateway proxy, written in Rust and optimized for maximum performance. This high-performance API gateway routes requests to various AI providers (OpenAI, Anthropic, GROQ, Fireworks, Together, AWS Bedrock) with streaming support, making it perfect for developers who need reliable and blazing-fast AI API access.
+An OpenAI-compatible, multi-provider AI gateway written in Rust, with streaming,
+provider-aware cost accounting, and Nova Guard policy enforcement.
 
 [![Rust](https://github.com/Noveum/ai-gateway/actions/workflows/rust.yml/badge.svg)](https://github.com/Noveum/ai-gateway/actions/workflows/rust.yml)
 [![Crates.io](https://img.shields.io/crates/v/noveum-ai-gateway.svg)](https://crates.io/crates/noveum-ai-gateway)
-[![License: MIT/Apache-2.0](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE-MIT)
-[![Docker Pulls](https://img.shields.io/docker/pulls/noveum/noveum-ai-gateway)](https://hub.docker.com/r/noveum/noveum-ai-gateway)
+[![docs.rs](https://docs.rs/noveum-ai-gateway/badge.svg)](https://docs.rs/noveum-ai-gateway)
+[![License: MIT/Apache-2.0](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/Noveum/ai-gateway/blob/v2.0.1/LICENSE-MIT)
 
-[Quick Start](#quick-start) • 
-[Documentation](docs/) • 
-[Pricing](docs/PRICING.md) • 
-[Docker](docs/deployment.md) • 
-[Contributing](docs/CONTRIBUTING.md)
+[Quick start](#five-minute-quick-start) ·
+[Documentation](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/README.md) ·
+[v2 migration](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/MIGRATING_TO_V2.md) ·
+[Nova Guard](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/NOVA_GUARD.md) ·
+[Operations](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/deployment.md)
 
 </div>
 
-## ✨ Features
+## What it does
 
-- 🚀 **Blazing fast performance**: Built in Rust with zero-cost abstractions
-- ⚡ **Optimized for low latency and high throughput**
-- 🔄 **Unified API interface for multiple AI providers**:
-  - OpenAI — [guide](docs/providers/openai.md)
-  - AWS Bedrock — [guide](docs/providers/bedrock.md)
-  - Anthropic — [guide](docs/providers/anthropic.md)
-  - GROQ — [guide](docs/providers/groq.md)
-  - Fireworks — [guide](docs/providers/fireworks.md)
-  - Together AI — [guide](docs/providers/together.md)
-  - Mistral, Cohere, Google Gemini, DeepSeek, xAI (Grok), OpenRouter, Perplexity — [OpenAI-compatible providers guide](docs/providers/openai-compatible.md)
-- 💰 **Per-request cost tracking** across all providers from a built-in,
-  versioned model pricing catalog — see [docs/PRICING.md](docs/PRICING.md).
-- 📡 **Real-time Streaming**: Optimized for minimal latency
-- 🛡️ **Nova Guard policy enforcement**: In-process guardrails — model allow/deny, regex, banned substrings, PII & secrets detection, JSON-schema validation, token caps — that block, redact, or flag requests and responses, loaded from a local policy bundle (file or inline). See [docs/NOVA_GUARD.md](docs/NOVA_GUARD.md).
-- 🛡️ **Production Ready**: Battle-tested in high-load environments
-- 🔍 **Health Checking**: Built-in monitoring
-- 📊 **Telemetry & Metrics**: Per-request token usage and cost tracking with a pluggable `MetricsExporter` trait; ships with a console exporter (set `DEBUG_METRICS=true`) for local debugging. See [docs/telemetry-plugins.md](docs/telemetry-plugins.md).
-- 🌐 **CORS Support**: Configurable cross-origin resource sharing
-- 🛠️ **SDK Compatibility**: Uses the OpenAI Chat Completions contract;
-  provider-specific supported-field subsets are documented in each guide
-- 🌍 **Deploy anywhere — one package, three shapes**: the same crate runs as a
-  native binary / **Docker** image, a **Rust library**, **or** a
-  **Cloudflare Worker** (WASM, true per‑PoP edge) sharing the same Nova Guard
-  engine. See [docs/CLOUDFLARE_WORKER.md](docs/CLOUDFLARE_WORKER.md).
+The gateway exposes one OpenAI Chat Completions surface. Select an upstream with
+the `x-provider` header; an absent header defaults to OpenAI. It supports:
 
-## ⚡ Performance
+- OpenAI, Anthropic, Groq, Fireworks, Together AI, and AWS Bedrock;
+- OpenAI-compatible routes for Mistral, Cohere, Gemini, DeepSeek, xAI,
+  OpenRouter, and Perplexity;
+- buffered and SSE responses, including Anthropic Messages-to-OpenAI stream
+  translation and Bedrock Converse translation (Bedrock streaming is native
+  only in v2.0.1);
+- a versioned pricing catalog with token, cache, long-context, and supported
+  tool-fee accounting;
+- local or platform-managed Nova Guard policies; and
+- native binary, Docker, Rust library, and Cloudflare Worker deployment shapes.
 
-Built in Rust (Axum + Tokio). The gateway adds negligible overhead on top of the
-upstream provider's own latency. Measured locally (release build, localhost,
-includes client + loopback round-trip):
+Provider features are not identical. Check the relevant
+[provider guide](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/README.md#providers)
+before relying on tools, vision,
+provider-native fields, or strict cost-cap admission.
 
-| Path | p50 | p99 |
-|---|---|---|
-| Health check (gateway processing only) | ~0.46 ms | ~0.87 ms |
-| Full Nova Guard path (JSON parse + regex + PII scan, request blocked, no upstream) | ~0.60 ms | ~1.08 ms |
+## Version 2.0.1
 
-So Nova Guard policy evaluation adds roughly **~0.15 ms** at p50, and when the
-engine is disabled or has no active policies the middleware short-circuits with
-**zero** body buffering. (Numbers vary by hardware; reproduce with the steps in
-[docs/deployment.md](docs/deployment.md).)
+The 2.0 line introduced platform-managed Nova Guard and its SemVer-major public
+API changes. Version 2.0.1 adds the static landing page, clearer runtime
+boundaries, and post-release hardening described in the
+[changelog](https://github.com/Noveum/ai-gateway/blob/v2.0.1/CHANGELOG.md#201---2026-08-24).
+Release resources:
 
-## 🚀 Quick Start
+- [crates.io package](https://crates.io/crates/noveum-ai-gateway)
+- [Rust API documentation](https://docs.rs/noveum-ai-gateway)
+- [GitHub releases](https://github.com/Noveum/ai-gateway/releases)
 
-### Installation
+Source, package, documentation, container, and production deployment can advance
+at different times. Confirm that each surface reports 2.0.1 before treating it
+as the release artifact or promotion target.
 
-You can install Noveum Gateway using one of these methods:
+The 2.0 line is SemVer-major relative to 1.x. Library consumers must account
+for changes to
+`AppState::new`, `Policy::policy_type`, and `PolicyEngine::from_env`; follow the
+[v1.2 → v2 migration guide](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/MIGRATING_TO_V2.md).
 
-### One Line Install & Run (With Cargo Install)
+## Five-minute quick start
+
+### 1. Install and start
+
+Rust 1.94.1 or newer is required.
 
 ```bash
-curl https://sh.rustup.rs -sSf | sh && cargo install noveum-ai-gateway && noveum-ai-gateway
+cargo install noveum-ai-gateway --version 2.0.1 --locked
+RUST_LOG=info noveum-ai-gateway
 ```
 
-#### Using Cargo Install
+The native server listens on `http://127.0.0.1:3000` by default and honors
+`HOST`. Confirm the exact binary version before sending provider traffic:
 
 ```bash
-cargo install noveum-ai-gateway
+curl --fail --silent http://127.0.0.1:3000/health
+# {"status":"healthy","version":"2.0.1"}
 ```
 
-After installation, you can start the gateway by running:
-```bash
-noveum-ai-gateway
-```
+### 2. Send one provider request
 
-#### Building from Source
-
-1. Clone the repository:
-```bash
-git clone https://github.com/noveum/ai-gateway
-cd ai-gateway
-```
-
-2. Build the project:
-```bash
-cargo build --release
-```
-
-3. Run the server:
-```bash
-cargo run --release
-```
-
-The server will start on `http://127.0.0.1:3000` by default.
-
-### Running the Gateway
+Provider credentials are supplied per request; the gateway does not keep them
+in its configuration. This OpenAI example uses an explicit output bound, which
+also makes it compatible with strict Nova Guard cost caps:
 
 ```bash
-# Basic configuration
-export RUST_LOG=info
-
-# Start the gateway
-noveum-ai-gateway
-
-# Or with custom port
-PORT=8080 noveum-ai-gateway
-```
-
-### Configuration (environment variables)
-
-**Server / runtime**
-
-| Variable | Default | Description |
-|---|---|---|
-| `PORT` | `3000` | TCP port to listen on |
-| `HOST` | `127.0.0.1` | Bind address |
-| `WORKER_THREADS` | derived from CPU cores | Tokio worker thread count |
-| `MAX_CONNECTIONS` | `10000` | Max idle HTTP connections kept per upstream host |
-| `RUST_LOG` | `info` | Log filter (e.g. `info`, `debug`, `noveum_ai_gateway=debug`) |
-
-**Telemetry (optional)**
-
-| Variable | Default | Description |
-|---|---|---|
-| `DEBUG_METRICS` | `false` | Register the console metrics exporter (prints each request's token/cost metrics) |
-| `DEPLOYMENT_ENVIRONMENT` | `development` | Value for the `deployment.environment` resource tag |
-
-**Nova Guard policy enforcement (optional)** — see [docs/NOVA_GUARD.md](docs/NOVA_GUARD.md):
-
-| Variable | Default | Description |
-|---|---|---|
-| `NOVEUM_GUARD_ENABLED` | `true` | Master switch for Nova Guard (accepts `false`/`0`/`no`/`off`/`disabled`) |
-| `NOVEUM_GUARD_POLICIES_FILE` | — | Path to a local `nova-guard.json` policy bundle |
-| `NOVEUM_GUARD_POLICIES` | — | Inline JSON policy bundle (alternative to the file) |
-| `NOVEUM_GUARD_BLOCK_RESPONSE_MODE` | `synthetic_success` | `synthetic_success` or `provider_error` |
-| `NOVEUM_GUARD_TENANCY` | _(unset)_ | Deployment mode of the platform bridge: `dedicated` (one process-wide project) or `shared` (project + organization derived per request from the caller's credential). Unset keeps the historical inference — the `NOVEUM_API_KEY` + `NOVEUM_GUARD_PROJECT_ID` pair means dedicated. **Shared is never inferred**; it is only ever entered by asking for it |
-| `NOVEUM_API_KEY` | — | Noveum platform API key. **Dedicated mode only** — with `NOVEUM_GUARD_PROJECT_ID` it activates platform-managed Nova Guard (policies + live cost/rate state fetched from the platform, usage reported back). Setting it alongside `NOVEUM_GUARD_TENANCY=shared` is a startup error. Native gateway only — the Cloudflare Worker rejects the shared configuration |
-| `NOVEUM_GUARD_PROJECT_ID` | — | Noveum project whose Nova Guard policies to enforce. **Dedicated mode only**; mutually exclusive with `NOVEUM_GUARD_TENANCY=shared` |
-| `NOVEUM_API_URL` | `https://api.noveum.ai` | Platform API base URL (both modes) |
-| `NOVEUM_GUARD_TENANT_TTL_SECS` | `300` | Shared mode: how long one credential→tenant resolution is reused. Matches the platform's own API-key cache, so the gateway is never *more* stale than the control plane it mirrors |
-| `NOVEUM_GUARD_TENANT_CACHE_MAX` | `1024` | Shared mode: how many distinct tenants one process keeps warm (compiled policies, counters, reservations). A tenant idle for 10 minutes is dropped, which is also what makes a revoked credential self-heal |
-| `OPENAI_BASE_URL` | `https://api.openai.com` | Send `x-provider: openai` traffic to a compatible upstream. Honored by both the native gateway and the Cloudflare Worker |
-| `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | Override the Anthropic upstream for `x-provider: anthropic`. Honored by both the native gateway and the Cloudflare Worker; requests still route to `/v1/messages` |
-| `NOVEUM_GUARD_COST_ENFORCEMENT` | policy setting | Native gateway only: `strict` forces every cost cap through platform-atomic admission; `advisory` forces the per-process ledger. Unset lets each policy's `enforcementMode` decide. `strict` without the platform bridge is a startup error |
-| `NOVEUM_GUARD_ASSUMED_OUTPUT_TOKENS` | `1024` | Fallback completion estimate for advisory cost caps and rate-only admission when a request has no explicit output limit. It is not used to admit an applicable enforcing/blocking strict cost cap: that request is rejected with HTTP 400 instead |
-| `NOVEUM_GUARD_WORKER_UPSTREAM_TIMEOUT_MS` | `600000` | Cloudflare Worker only: deadline for an admitted provider fetch/body/stream. It may be lowered to a positive value but not raised above 10 minutes, so an active request is abandoned before the platform can reap its 15-minute reservation lease |
-| `NOVEUM_GUARD_ALLOW_UNGUARDED_START` | `false` | **Emergency use only.** Lets the gateway start when the first platform policy fetch fails, serving traffic with *no* enforcement until a later poll succeeds. Without it, that failure aborts startup |
-
-### Platform-managed Nova Guard: the two deployment modes
-
-Platform-managed Nova Guard runs in one of **two mutually exclusive modes**,
-selected by `NOVEUM_GUARD_TENANCY`. Which one you need is decided by a single
-question: *does this deployment serve more than one tenant?*
-
-| | **Dedicated** | **Shared** |
-|---|---|---|
-| `NOVEUM_GUARD_TENANCY` | `dedicated`, or unset | `shared` |
-| Tenant identity | fixed by the environment | derived per request from the caller's credential |
-| `NOVEUM_API_KEY` | **required** (one process-wide service key) | **must be unset** |
-| `NOVEUM_GUARD_PROJECT_ID` | **required** | **must be unset** |
-| Caller must authenticate to the gateway | no | **yes**, `x-noveum-api-key` on every `/v1/*` request |
-| Local policy bundle alongside it | allowed | **refused at startup** |
-| Use it for | one team's own gateway | a gateway serving several tenants, e.g. `gateway.noveum.ai` |
-
-Setting both modes' variables at once is a startup error rather than a
-precedence rule — which mode wins is exactly the kind of question that must
-never be answered silently.
-
-#### Dedicated mode
-
-`NOVEUM_GUARD_PROJECT_ID` is process-wide, so **every request a replica handles
-is metered and capped against that one project, regardless of who sent it.**
-That is correct for a gateway fronting a single team, and wrong for anything
-else. Policies are fetched once at startup (a failed first fetch aborts
-startup) and refreshed by a background poller.
-
-#### Shared mode
-
-Every `/v1/*` caller authenticates to the gateway with its own Noveum API key,
-and the project + organization to enforce against are derived **server-side**
-from that credential. Each derived tenant gets its own isolated runtime:
-compiled policies, live counters, reservations, usage reporting and cache
-entries are all keyed by the derived tenant, never by anything the client sent.
-
-- **The credential goes in `x-noveum-api-key`**, not `Authorization` — on this
-  gateway `Authorization` already carries the caller's *provider* key and is
-  forwarded upstream. The tenancy layer **removes** `x-noveum-api-key` from the
-  request before proxying, so a tenant's Noveum credential never reaches
-  OpenAI, Anthropic or any other provider. A `Bearer ` prefix is tolerated.
-- **Routing headers are filters, never identity.** `x-project-id` may only
-  *select among* the projects the credential is already entitled to; naming any
-  other project is **rejected**, not silently overridden. `x-organization-id`
-  (either spelling) is checked against the derived organization and must match.
-  With no `x-project-id` and exactly one entitled project, that project is
-  used; with several, the request is refused rather than metered against a
-  guess.
-- **Every resolution failure fails closed.** An unusable, unverifiable or
-  unentitled credential never falls through to a default project, and a tenant
-  whose policies cannot be fetched is refused rather than served unguarded.
-  Refusals are `401` (no or rejected credential), `403` (authenticated but not
-  entitled — answered identically for "another organization's project" and "no
-  such project", so it discloses nothing), `400` (entitled to several projects
-  and the request named none) and `503` (no verdict reachable).
-- **Nothing is fetched at startup** — there is no tenant yet. A misconfiguration
-  still aborts at boot, but policy fetches happen on each tenant's first
-  request.
-- **`/health` needs no credential**, so liveness and readiness probes work
-  unchanged. Only `/v1/*` requires a tenant.
-- **A local policy bundle is refused.** `NOVEUM_GUARD_POLICIES` /
-  `NOVEUM_GUARD_POLICIES_FILE` alongside `NOVEUM_GUARD_TENANCY=shared` aborts
-  startup: a process-wide bundle would be loaded and never consulted, and a
-  process-wide `cost_cap` / `rate_limit` would be one counter shared by every
-  tenant.
-
-#### Key permissions
-
-Use a **scoped Noveum service key**, not a personal or full-access one:
-
-| Permission | Needed for | Mode |
-|---|---|---|
-| `guardrails:read` | fetching `/policies/effective` and live `/policies/state` | both |
-| `guardrails:ingest` | reporting usage to `/policies/usage` and settling reservations | both |
-| `projects:read` | deriving the caller's project + organization from the credential | shared only |
-
-In dedicated mode that key is the deployment's own, supplied once via
-`NOVEUM_API_KEY`. In shared mode there is **no process-wide key at all** —
-every platform call is made with the calling tenant's own credential, so each
-caller's key needs these permissions and no single secret is ever applied to
-another tenant's traffic.
-
-#### Shared mode is native-only
-
-The Cloudflare Worker supports **dedicated** platform-managed Nova Guard
-(policies, live state, atomic admission and settlement all work at the edge).
-It has no tenancy layer, so it cannot serve shared mode, and it answers
-`NOVEUM_GUARD_TENANCY=shared` with a 503 `gateway_configuration_error` rather
-than ignoring the variable and proxying every caller unguarded. It likewise
-refuses *any* inline `cost_cap` / `rate_limit` policy, which has no live-state
-backend — see
-[docs/CLOUDFLARE_WORKER.md](docs/CLOUDFLARE_WORKER.md#platform-managed-nova-guard-on-the-worker).
-
-#### Deployment order
-
-The platform's composite `/state` (the nested `org` block) must be deployed
-**before** a gateway that enforces organization-scoped policies. Reversed,
-org-scoped counters read as unavailable and expected fail-closed policies block
-during the rollout.
-
-> **Whether a cap holds across replicas depends on its enforcement mode.**
->
-> | Active policy for this model | Request has a positive explicit output limit | No explicit output limit |
-> |---|---|---|
-> | Enforcing, blocking **strict** `cost_cap` | Reserved against the platform's atomic admission API, then settled with actual usage | **HTTP 400 `missing_output_limit` before admission or provider dispatch** |
-> | **Advisory** `cost_cap` | Heuristic estimate (native: per-process ledger; Worker: stateful platform bridge without promotion to strict semantics) | Allowed using `NOVEUM_GUARD_ASSUMED_OUTPUT_TOKENS`; this is an estimate, not a hard cap |
-> | `rate_limit` only | Normal rate admission | Allowed using the fallback estimate where token accounting needs one; rate-only policies do not acquire the strict cost-cap requirement |
-> | Strict cap in `shadow` mode, disabled, or outside `scopeToModels` | Does not impose the strict output-limit requirement | Does not impose the strict output-limit requirement |
->
-> The accepted limit fields are `max_tokens`, `max_completion_tokens`, and
-> `max_output_tokens`; every non-null field must be the same positive integer no
-> greater than 10,000,000 under strict admission. Compatible providers receive
-> one normalized native ceiling, so the amount reserved is the amount enforced
-> upstream. On the native gateway,
-> `NOVEUM_GUARD_COST_ENFORCEMENT=strict` promotes otherwise-advisory caps to the
-> strict row, while `...=advisory` demotes policy-declared strict caps. Unset lets
-> each policy decide. Native advisory enforcement can overshoot by the requests
-> admitted in the refresh window *per replica*. The Worker still sends stateful
-> traffic through its platform bridge, but that transport choice does not turn
-> an advisory policy into a hard cap; only atomic strict admission provides the
-> cross-replica hard-cap contract.
->
-> Strict admission deliberately supports only bounded JSON
-> `/v1/chat/completions`. It requires `model`, `messages`, and a positive output
-> limit, estimates the post-transform serialized body, and rejects unbounded
-> provider-side work before admission: Responses/conversation state, images,
-> files, audio, remote search (including xAI `search_parameters`), server/MCP
-> tools, conflicting output-limit aliases, multi-choice requests,
-> Perplexity, and OpenRouter. Client function tools remain supported on adapters
-> that translate or transparently pass them; the Bedrock adapter does not yet
-> translate tool use. Strict Bedrock admission currently accepts only
-> catalogued commercial Claude model/profile IDs whose global or geographic
-> price is derivable from the ID; region-priced Nova/Titan models remain
-> available to advisory/pass-through traffic. Direct OpenAI strict calls are
-> pinned to `service_tier: "default"`; advisory policies retain the gateway's broader
-> transparent-proxy surface.
-
-> **An unknown model is priced high, not rejected.** A model id the compiled
-> Rust pricing table does not know is estimated at that runtime table's maximum
-> input/output rates (today $15/$75 per 1M), tagged as an assumption, and logged
-> once per distinct id. It is reserved at that rate too, so it cannot consume
-> cap headroom it will later be
-> billed for. The gateway does not refuse unrecognized model ids — it is a
-> pass-through proxy, and doing so would break every provider model launch. To
-> refuse calls you cannot meter, set `failClosed: true` on a `cost_cap`: that
-> blocks an unpriceable model, per policy rather than globally.
-
-> **Costs are policy estimates, not billing.** The catalog models uncached
-> input/output, published cache-read and cache-write rates, long-context tiers,
-> known per-request tool fees, and supported Anthropic geo/fast multipliers. A
-> declared Anthropic cache breakpoint reserves the first-write premium; omitted
-> eligible geo reserves the possible 1.1x US premium; Opus 5/4.8 fast mode
-> reserves 2x, or 2.2x with US geo. A usage dimension the provider reports but
-> the catalog cannot price is charged at a conservative bound and marked
-> incomplete. Batch discounts, negotiated rates, taxes, and later provider
-> changes can still differ. OpenAI Fast/Priority and regional-processing
-> premiums are not modeled; strict direct-OpenAI admission pins the default
-> service tier, while advisory traffic can still differ. Bedrock Claude
-> direct/geographic inference uses the documented 1.1x
-> token/cache rate while an explicit `global.` profile uses the global rate.
-> Strict admission rejects other Bedrock model families until `x-aws-region`
-> is carried through reservation and settlement; AWS publishes materially
-> different Nova rates by source Region.
-> Do not treat these figures as an invoice; see the
-> [versioned pricing and accounting guide](docs/PRICING.md).
-
-> **A configured guard never degrades to a silent pass-through.** Half-applied
-> credentials (one of `NOVEUM_API_KEY` / `NOVEUM_GUARD_PROJECT_ID`), empty
-> values, a malformed policy bundle, or a failed first policy fetch all abort
-> startup with a non-zero exit rather than booting a gateway that looks healthy
-> while enforcing nothing. An *absent* configuration is still a normal
-> transparent proxy.
-
-## 📚 Usage Examples
-
-### Making Requests
-
-To make requests through the gateway, use the `/v1/*` endpoint and specify the provider using the `x-provider` header.
-
-#### Example: AWS Bedrock Request
-
-```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "x-provider: bedrock" \
-  -H "x-aws-access-key-id: YOUR_ACCESS_KEY" \
-  -H "x-aws-secret-access-key: YOUR_SECRET_KEY" \
-  -H "x-aws-region: us-east-1" \
-  -d '{
-    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
-    "messages": [{"role": "user", "content": "Hello!"}]
-  }'
-```
-
-#### Example: OpenAI Request
-
-```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl --fail-with-body http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
   -H "Content-Type: application/json" \
   -H "x-provider: openai" \
-  -H "Authorization: Bearer your-openai-api-key" \
   -d '{
-    "model": "gpt-4",
-    "messages": [{"role": "user", "content": "Hello!"}]
+    "model": "gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Reply with: gateway ready"}],
+    "max_tokens": 32
   }'
 ```
 
-#### Example: GROQ Request
+Change `x-provider`, the provider credential, and the model to switch
+upstreams. See the [provider examples](#provider-authentication-examples).
+
+### Build from source instead
 
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "x-provider: groq" \
-  -H "Authorization: Bearer your-groq-api-key" \
-  -d '{
-    "model": "openai/gpt-oss-20b",
-    "messages": [{"role": "user", "content": "Hello!"}],
-    "stream": true,
-    "max_tokens": 300
-  }'
+git clone https://github.com/Noveum/ai-gateway.git
+cd ai-gateway
+cargo run --locked --release
 ```
 
-#### Example: Anthropic Request
+Run `cargo test --locked --lib` before modifying the source. The full release
+matrix is in
+[Validation](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/VALIDATION.md).
+
+## HTTP surface
+
+| Route | Purpose |
+|---|---|
+| `GET /`, `HEAD /` | Beginning with v2.0.1, a static no-JavaScript information page showing runtime/version and links to health, docs.rs, GitHub, and Noveum. `HEAD` returns the same status and security/cache headers without a body. |
+| `GET /health` | Process/runtime health and exact package version. It does not test provider credentials. |
+| `/v1/*` | Provider proxy surface; `POST /v1/chat/completions` is the documented contract. |
+
+The landing page is not an admin console or hosted API explorer.
+`/docs` and `/openapi.json` remain 404; use
+[docs.rs](https://docs.rs/noveum-ai-gateway) and this documentation instead.
+
+## Authentication: three different credentials
+
+These credentials have different jobs and must not be substituted for one
+another:
+
+| Credential | Where it goes | Purpose |
+|---|---|---|
+| Provider API key | Usually `Authorization: Bearer …` on each request; Anthropic also accepts `x-api-key`; Bedrock uses `x-aws-*` headers | Authenticates the upstream model call and is forwarded only to that provider |
+| Dedicated Noveum service key | `NOVEUM_API_KEY` deployment secret | Lets one dedicated gateway fetch policies/state and admit/settle usage for the fixed `NOVEUM_GUARD_PROJECT_ID` |
+| Shared-mode caller key | `x-noveum-api-key` on each request to a **native** shared gateway | Authenticates the caller to Noveum and derives the caller's entitled project/organization; it is stripped before provider dispatch |
+
+`x-project-id` and `x-organization-id` are not credentials. In transparent or
+dedicated mode they are attribution headers. In shared mode they may only
+select or confirm an identity already derived from the caller's Noveum key.
+
+The transparent and dedicated gateway modes do **not** provide general-purpose
+client authentication. Put a production deployment behind an authenticated
+load balancer, API gateway, Cloudflare Access, or another access-control layer
+when the endpoint must not be public.
+
+### Noveum key scopes
+
+Use the least-privileged key that fits the tenancy mode:
+
+| Scope | Dedicated service key | Shared caller key |
+|---|:---:|:---:|
+| `guardrails:read` | required | required |
+| `guardrails:ingest` | required | required |
+| `projects:read` | not required | required |
+
+Never put `NOVEUM_API_KEY` in `wrangler.toml`, a Docker image, source control,
+or a request header. Store it in the runtime's secret manager.
+
+## Provider authentication examples
+
+All examples use the OpenAI Chat Completions request shape.
+
+### Anthropic
 
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl --fail-with-body http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer $ANTHROPIC_API_KEY" \
   -H "Content-Type: application/json" \
   -H "x-provider: anthropic" \
-  -H "Authorization: Bearer your-anthropic-api-key" \
   -d '{
-    "model": "claude-sonnet-5",
-    "messages": [{"role": "user", "content": "Write a poem"}],
-    "stream": true,
-    "max_tokens": 1024
+    "model": "claude-haiku-4-5-20251001",
+    "messages": [{"role": "user", "content": "Reply with one sentence."}],
+    "max_tokens": 64
   }'
 ```
 
-#### Example: Fireworks Request
+The gateway converts the request to Anthropic Messages and converts successful
+buffered/SSE responses back to OpenAI shape. See the
+[Anthropic compatibility contract](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/providers/anthropic.md).
+
+### Groq, Fireworks, Together, and other compatible providers
 
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl --fail-with-body http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer $GROQ_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "x-provider: fireworks" \
-  -H "Authorization: Bearer your-fireworks-api-key" \
+  -H "x-provider: groq" \
   -d '{
-    "model": "accounts/fireworks/models/llama-v3p1-8b-instruct",
-    "messages": [{"role": "user", "content": "Write a poem"}],
+    "model": "openai/gpt-oss-20b",
+    "messages": [{"role": "user", "content": "Reply with one sentence."}],
+    "max_tokens": 64,
     "stream": true,
-    "max_tokens": 300,
-    "temperature": 0.6,
-    "top_p": 1,
-    "top_k": 40
+    "stream_options": {"include_usage": true}
   }'
 ```
 
-#### Example: Together AI Request
+Use the upstream provider's current model list; model availability is not
+frozen by the gateway. See
+[Groq](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/providers/groq.md),
+[Fireworks](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/providers/fireworks.md),
+[Together](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/providers/together.md),
+and
+[other OpenAI-compatible providers](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/providers/openai-compatible.md).
+
+### AWS Bedrock
 
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl --fail-with-body http://127.0.0.1:3000/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "x-provider: together" \
-  -H "Authorization: Bearer your-together-api-key" \
+  -H "x-provider: bedrock" \
+  -H "x-aws-access-key-id: $AWS_ACCESS_KEY_ID" \
+  -H "x-aws-secret-access-key: $AWS_SECRET_ACCESS_KEY" \
+  -H "x-aws-region: ${AWS_REGION:-us-east-1}" \
   -d '{
-    "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
-    "messages": [{"role": "user", "content": "Write a poem"}],
-    "stream": true,
-    "max_tokens": 512,
-    "temperature": 0.7,
-    "top_p": 0.7,
-    "top_k": 50,
-    "repetition_penalty": 1
+    "model": "amazon.nova-micro-v1:0",
+    "messages": [{"role": "user", "content": "Reply with one sentence."}],
+    "max_tokens": 64
   }'
 ```
 
-## SDK Compatibility
+Both native and Cloudflare runtimes accept `x-aws-session-token` for temporary
+STS credentials. Use least-privileged, short-lived AWS credentials and only
+send credential headers over TLS to a gateway you control. Do not send AWS
+credentials through the public/shared `gate.noveum.ai` endpoint. See the
+[Bedrock guide](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/providers/bedrock.md).
 
-The gateway exposes an OpenAI Chat Completions interface. You can use an official
-OpenAI SDK with supported providers by changing the base URL, provider header,
-and provider API key. Provider-specific translations are necessarily a subset of
-the OpenAI schema; for Anthropic's exact request, streaming, tool, and error
-contract, read the [Anthropic provider guide](docs/providers/anthropic.md).
-That adapter validates cost-affecting cache, geo, speed, fallback, and
-model-specific sampling fields before Nova Guard admission. It supports client
-function tools, not Anthropic-managed server/MCP tools.
+When the environment contains temporary credentials, add this header to the
+Bedrock request; omit it for a long-lived access-key pair:
 
-### Using with OpenAI's Official Node.js SDK
-
-```typescript
-import OpenAI from 'openai';
-
-// Configure the SDK to use Noveum Gateway
-const openai = new OpenAI({
-  apiKey: process.env.PROVIDER_API_KEY, // Use any provider's API key
-  baseURL: "http://localhost:3000/v1/", // Point to the gateway
-  defaultHeaders: {
-    "x-provider": "groq", // Specify the provider you want to use
-  },
-});
-
-// Make requests as usual
-const chatCompletion = await openai.chat.completions.create({
-  messages: [
-    { role: "system", content: "Write a poem" },
-    { role: "user", content: "" }
-  ],
-  model: "openai/gpt-oss-20b",
-  temperature: 1,
-  max_tokens: 100,
-  top_p: 1,
-  stream: false,
-});
+```bash
+-H "x-aws-session-token: $AWS_SESSION_TOKEN"
 ```
 
-You can easily switch between providers by changing the `x-provider` header and API key:
+## OpenAI SDK example
 
 ```typescript
-// For OpenAI
-const openaiClient = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-  baseURL: "http://localhost:3000/v1/",
-  defaultHeaders: { "x-provider": "openai" },
-});
+import OpenAI from "openai";
 
-// For AWS Bedrock
-const bedrockClient = new OpenAI({
-  apiKey: process.env.AWS_ACCESS_KEY_ID, // Use AWS access key
-  baseURL: "http://localhost:3000/v1/",
-  defaultHeaders: {
-    "x-provider": "bedrock",
-    "x-aws-access-key-id": process.env.AWS_ACCESS_KEY_ID,
-    "x-aws-secret-access-key": process.env.AWS_SECRET_ACCESS_KEY,
-    "x-aws-region": process.env.AWS_REGION || "us-east-1"
-  },
-});
-
-// For Anthropic
-const anthropicClient = new OpenAI({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  baseURL: "http://localhost:3000/v1/",
-  defaultHeaders: { "x-provider": "anthropic" },
-});
-
-// For GROQ
-const groqClient = new OpenAI({
+const client = new OpenAI({
   apiKey: process.env.GROQ_API_KEY,
-  baseURL: "http://localhost:3000/v1/",
+  baseURL: "http://127.0.0.1:3000/v1",
   defaultHeaders: { "x-provider": "groq" },
 });
 
-// For Fireworks
-const fireworksClient = new OpenAI({
-  apiKey: process.env.FIREWORKS_API_KEY,
-  baseURL: "http://localhost:3000/v1/",
-  defaultHeaders: { "x-provider": "fireworks" },
+const completion = await client.chat.completions.create({
+  model: "openai/gpt-oss-20b",
+  messages: [{ role: "user", content: "Reply with one sentence." }],
+  max_tokens: 64,
 });
 
-// For Together AI
-const togetherClient = new OpenAI({
-  apiKey: process.env.TOGETHER_API_KEY,
-  baseURL: "http://localhost:3000/v1/",
-  defaultHeaders: { "x-provider": "together" },
-});
+console.log(completion.choices[0]?.message.content);
 ```
 
-The gateway automatically handles the necessary transformations to ensure compatibility with each provider's API format while maintaining the familiar OpenAI SDK interface.
-
-### Testing Gateway URL
-```
-https://gateway.noveum.ai
-```
-
-### Send Example Request to Testing Gateway
-```bash
-curl --location 'https://gateway.noveum.ai/v1/chat/completions' \
-  --header 'Authorization: Bearer YOUR_API_KEY' \
-  --header 'Content-Type: application/json' \
-  --header 'x-provider: groq' \
-  --data '{
-    "model": "openai/gpt-oss-20b",
-    "messages": [
-        {
-            "role": "user",
-            "content": "Write a poem"
-        }
-    ],
-    "stream": true,
-    "max_tokens": 300
-}'
-```
-
-> **Note**: This deployment is provided for testing and evaluation purposes only. For production workloads, please deploy your own instance of the gateway or contact us for information about production-ready managed solutions.
-
-## 🔧 Configuration
-
-The gateway can be configured using environment variables:
-
-```bash
-RUST_LOG=debug # Logging level (debug, info, warn, error)
-```
-
-## 🏗️ Architecture
-
-The gateway leverages the best-in-class Rust ecosystem:
-
-- **Axum** - High-performance web framework
-- **Tokio** - Industry-standard async runtime
-- **Tower-HTTP** - Robust HTTP middleware
-- **Reqwest** - Fast and reliable HTTP client
-- **Tracing** - Zero-overhead logging and diagnostics
-
-## 📈 Performance
-
-Noveum Developer AI Gateway is designed for maximum performance:
-
-- **Zero-cost abstractions** using Rust's ownership model
-- **Asynchronous I/O** with Tokio for optimal resource utilization
-- **Connection pooling** via Reqwest for efficient HTTP connections
-- **Memory-efficient** request/response proxying
-- **Minimal overhead** in the request path
-- **Optimized streaming** response handling
-
-## 🔒 Security Notes
-
-- Always run behind a reverse proxy in production
-- Configure CORS appropriately for your use case
-- Use environment variables for sensitive configuration
-- Consider adding rate limiting for production use
-
-## 🤝 Contributing
-
-We welcome contributions! Please see our [CONTRIBUTING.md](docs/CONTRIBUTING.md) for guidelines.
-
-### 🛠️ Development Setup
-
-```bash
-# Install development dependencies
-cargo install cargo-watch
-
-# Run tests
-cargo test
-
-# Run with hot reload
-cargo watch -x run
-```
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Connection Refused**
-   - Check if port 3000 is available
-   - Verify the HOST and PORT settings
-
-2. **Streaming Not Working**
-   - Ensure `Accept: text/event-stream` header is set
-   - Check client supports streaming
-   - Verify provider supports streaming for the requested endpoint
-
-3. **Provider Errors**
-   - Verify provider API keys are correct
-   - Check provider-specific headers are properly set
-   - Ensure the provider endpoint exists and is correctly formatted
-
-## 💬 Community
-
-- [GitHub Discussions](https://github.com/noveum/ai-gateway/discussions)
-- [Twitter](https://twitter.com/noveum-ai)
-
-## 🙏 Acknowledgments
-
-Special thanks to all [contributors](https://github.com/noveum/ai-gateway/graphs/contributors) and the Rust community.
-
-## 📄 License
-
-This project is dual-licensed under both the MIT License and the Apache License (Version 2.0). You may choose either license at your option. See the [LICENSE-MIT](LICENSE-MIT) and [LICENSE-APACHE](LICENSE-APACHE) files for details.
-
-## Docker Support
-
-### Building and Running with Docker
-
-1. Build the Docker image:
-```bash
-docker buildx build --platform linux/amd64 -t noveum/noveum-ai-gateway:latest . --load
-```
-
-2. Push the image to Docker Hub:
-```bash
-docker push noveum/noveum-ai-gateway:latest
-```
-
-3. Run the container:
-```bash
-docker run -p 3000:3000 \
-  -e RUST_LOG=info \
-  noveum/noveum-ai-gateway:latest
-```
-
-### Using Pre-built Docker Image
-
-```bash
-docker pull noveum/noveum-ai-gateway:latest
-docker run -p 3000:3000 \
-  -e RUST_LOG=info \
-  noveum/noveum-ai-gateway:latest
-```
-
-### Using Pre-built Docker Image with Nova Guard policies
-
-Mount a local policy bundle and point Nova Guard at it:
-
-```bash
-docker pull noveum/noveum-ai-gateway:latest  --platform linux/amd64
-docker run --platform linux/amd64 -p 3000:3000 \
-  -e RUST_LOG=info \
-  -e NOVEUM_GUARD_POLICIES_FILE=/etc/nova-guard.json \
-  -v "$(pwd)/nova-guard.json:/etc/nova-guard.json:ro" \
-  noveum/noveum-ai-gateway:latest
-```
-
-### Docker Compose
-
-For detailed deployment instructions, please refer to the [Deployment Guide](docs/deployment.md).
-
-#### Option 1: Build from Source
-
-Create a `docker-compose.yml` file:
-
-```yaml
-version: '3.8'
-services:
-  gateway:
-    build: .
-    platform: linux/amd64
-    ports:
-      - "3000:3000"
-    environment:
-      - RUST_LOG=info
-    restart: unless-stopped
-```
-
-#### Option 2: Use Prebuilt Image
-
-Create a `docker-compose.yml` file:
-
-```yaml
-version: '3.8'
-services:
-  gateway:
-    image: noveum/noveum-ai-gateway:latest
-    platform: linux/amd64
-    ports:
-      - "3000:3000"
-    environment:
-      - RUST_LOG=info
-    restart: unless-stopped
-```
-
-Then run either option with:
-```bash
-docker-compose up -d
-```
-
-#### Option 3: Use Prebuilt Image with Nova Guard policies
-
-Create a `docker-compose.yml` that mounts a local policy bundle:
-
-```yaml
-version: '3.8'
-services:
-  gateway:
-    image: noveum/noveum-ai-gateway:latest
-    platform: linux/amd64
-    ports:
-      - "3000:3000"
-    environment:
-      - RUST_LOG=info
-      - NOVEUM_GUARD_POLICIES_FILE=/etc/nova-guard.json
-    volumes:
-      - ./nova-guard.json:/etc/nova-guard.json:ro
-    restart: unless-stopped
-```
-
-Then run with:
-```bash
-docker-compose up -d
-```
-
-## Release Process for noveum-ai-gateway
-
-Publishing a crate is permanent: a version cannot be overwritten or deleted
-from crates.io. Perform releases only from a reviewed, deployed, and clean
-`main` commit. If a published version is unsafe, it can be yanked to prevent new
-dependency resolution, but existing lockfiles and direct downloads continue to
-work.
-
-### 1. Prepare and review the release
-
-- [ ] Merge the implementation PR and complete its production deployment gates.
-- [ ] Choose the version according to SemVer; public Rust API breaks require a
-      major version.
-- [ ] Update the version in both `Cargo.toml` and `Cargo.lock`.
-- [ ] Move the release notes out of `[Unreleased]` in `CHANGELOG.md` and update
-      its comparison links.
-- [ ] Ensure the release commit contains no credentials and the package list
-      contains only intentional files.
-
-```bash
-git switch main
-git pull --ff-only
-git status --short
-
-cargo fmt --all -- --check
-cargo clippy --locked --all-targets --all-features -- -D warnings
-cargo test --locked --lib
-cargo test --locked --test novaguard_platform
-cargo test --locked --test policy_integration
-cargo check --locked --target wasm32-unknown-unknown --no-default-features --lib
-cargo build --locked --release
-cargo package --locked --list
-cargo publish --locked --dry-run
-```
-
-Run the Cloudflare Worker/Workerd, Docker, supply-chain, and real-provider smoke
-gates documented above as well. The Cargo dry-run verifies the crate archive;
-it does not validate a production Cloudflare deployment or the Noveum control
-plane.
-
-### 2. Publish the exact reviewed commit
-
-Confirm `HEAD` is the reviewed release commit on `origin/main`, the tree is
-clean, and the version does not already exist on crates.io. Then publish once:
-
-```bash
-git fetch origin main
-test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
-test -z "$(git status --porcelain)"
-
-cargo publish --locked
-```
-
-Cargo uses a scoped crates.io token from the local credential provider or
-`CARGO_REGISTRY_TOKEN`. Never place the token in this repository, a shell
-history entry, or release output.
-
-### 3. Tag and verify
-
-After crates.io confirms the publish, tag that same commit and create the GitHub
-release from the matching changelog section:
-
-```bash
-NOVEUM_RELEASE_VERSION=2.0.0
-git tag -a "v${NOVEUM_RELEASE_VERSION}" -m "v${NOVEUM_RELEASE_VERSION}"
-git push origin "v${NOVEUM_RELEASE_VERSION}"
-gh release create "v${NOVEUM_RELEASE_VERSION}" --verify-tag \
-  --title "v${NOVEUM_RELEASE_VERSION}" --generate-notes
-```
-
-Verify the crate version and checksum on
-[crates.io](https://crates.io/crates/noveum-ai-gateway), wait for the matching
-[docs.rs](https://docs.rs/noveum-ai-gateway) build, and verify the GitHub tag and
-release resolve to the exact published source commit. For an emergency yank:
-
-```bash
-cargo yank --vers 2.0.0 noveum-ai-gateway
-```
-
-## Testing Deployment
-
-Noveum provides a testing deployment of the AI Gateway, hosted in our London data centre. This deployment is intended for testing and evaluation purposes only, and should not be used for production workloads.
-
-## 📊 OpenTelemetry Logging
-
-Noveum AI Gateway now supports OpenTelemetry compatible logs for enhanced observability. The Gateway can export detailed request logs with a rich structured format that includes complete request/response details and performance metrics.
-
-### Tracking Headers
-
-You can add custom tracking information to your requests that will be included in the logs:
-
-```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "x-provider: openai" \
-  -H "Authorization: Bearer your-openai-api-key" \
-  -H "x-project-id: your-project-id" \
-  -H "x-organization-id: your-org-id" \
-  -H "x-user-id: your-user-id" \
-  -d '{
-    "model": "gpt-4",
-    "messages": [{"role": "user", "content": "Hello!"}]
-  }'
-```
-
-These headers will be included in the telemetry logs, allowing you to:
-
-- Track usage by project
-- Monitor costs per organization
-- Analyze performance by user
-- Segment analytics by experiment
-
-For more details, see the [Telemetry Exporters Guide](docs/telemetry-plugins.md).
-
-## Testing
-
-Noveum Gateway includes comprehensive integration tests for all supported providers (OpenAI, Anthropic, GROQ, Fireworks, Together AI, and AWS Bedrock). These tests validate both non-streaming and streaming functionality.
-
-### Running Integration Tests
-
-1. Set up your test environment:
-   ```bash
-   # Copy the sample test environment file
-   cp tests/.env.test.example .env.test
-   
-   # Edit the file to add your API keys for the providers you want to test
-   nano .env.test
-   ```
-
-2. Start the gateway:
-   ```bash
-   cargo run
-   ```
-
-3. Run the integration tests:
-   ```bash
-   # Run all tests
-   cargo test --test run_integration_tests -- --nocapture
-   
-   # Run tests for specific providers
-   cargo test --test run_integration_tests openai -- --nocapture
-   cargo test --test run_integration_tests anthropic -- --nocapture
-   cargo test --test run_integration_tests groq -- --nocapture
-   cargo test --test run_integration_tests fireworks -- --nocapture
-   cargo test --test run_integration_tests together -- --nocapture
-   cargo test --test run_integration_tests bedrock -- --nocapture
-   ```
-
-### Test Environment Configuration
-
-Your `.env.test` file should include the following variables:
-
-```bash
-# Gateway URL (default: http://localhost:3000)
-GATEWAY_URL=http://localhost:3000
-
-# Provider API Keys - Add keys for the providers you want to test
-OPENAI_API_KEY=your_openai_api_key
-ANTHROPIC_API_KEY=your_anthropic_api_key
-GROQ_API_KEY=your_groq_api_key
-FIREWORKS_API_KEY=your_fireworks_api_key
-TOGETHER_API_KEY=your_together_api_key
-
-# AWS Bedrock Credentials
-AWS_ACCESS_KEY_ID=your_aws_access_key_id
-AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
-AWS_REGION=us-east-1
-```
-
-For detailed test documentation, please refer to the [Integration Tests README](tests/README.md).
+In native shared-tenancy mode, also add `x-noveum-api-key` and, if the key can
+access several projects, `x-project-id` to `defaultHeaders`.
+
+## Nova Guard deployment choices
+
+| Mode | Runtime | Tenant identity | Appropriate use |
+|---|---|---|---|
+| Transparent | Native or Worker | none | Routing only; no platform policy/state bridge |
+| Local stateless policies | Native or Worker | process-wide bundle | Regex, PII, secrets, allowlists, schema, and token policies without the Noveum control plane |
+| Platform-managed dedicated | Native or Worker | fixed deployment key + project | One team's gateway or one Worker/domain per project |
+| Platform-managed shared | **Native only** | derived from each caller's Noveum key | A hostname serving several projects or organizations |
+
+Do not enable a dedicated project binding on a shared public hostname: every
+call would be attributed and capped against that one project. A shared-hostname
+Cloudflare Worker must remain transparent, be split into dedicated Workers per
+project, or be replaced by the native shared-tenancy gateway.
+
+The production Cloudflare endpoint `https://gate.noveum.ai` runs in
+**transparent** mode for this reason. Check its public `/health` response for
+the exact deployed version; v2.0.0 was the verified 2026-08-24 release baseline.
+Provider requests still require the caller's provider credential. This status
+is operational information, not a guarantee that the public endpoint is an
+SLA-backed managed service.
+
+Read
+[Nova Guard](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/NOVA_GUARD.md)
+for policy semantics and
+[Cloudflare Worker operations](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/CLOUDFLARE_WORKER.md)
+before enabling the platform bridge.
+
+## Configuration
+
+The common native settings are:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `HOST` | `127.0.0.1` | Listen address. Use `0.0.0.0` inside a container. |
+| `PORT` | `3000` | Listen port |
+| `RUST_LOG` | `info` | Tracing filter |
+| `DEBUG_METRICS` | `false` | Emit request metrics to the console; may include prompt/response content |
+| `DEPLOYMENT_ENVIRONMENT` | `development` | Telemetry resource label |
+| `NOVEUM_GUARD_ENABLED` | `true` | Nova Guard master switch; no source means transparent pass-through |
+
+The complete, mode-aware reference is in
+[Configuration](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/configuration.md).
+Invalid or half-applied guard
+configuration is rejected instead of silently disabling enforcement: at native
+startup, or on Worker proxy requests while its information/health routes remain
+available.
+
+## Deploy and operate
+
+- [Native, Docker, and Kubernetes](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/deployment.md)
+- [Cloudflare Worker runbook](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/CLOUDFLARE_WORKER.md)
+- [Cloudflare architecture and runtime differences](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/CLOUDFLARE_DEPLOYMENT.md)
+- [Validation checklist](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/VALIDATION.md)
+- [Telemetry and log handling](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/logs.md)
+- [Release process](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/RELEASING.md)
+
+Always pin an immutable version in production. Confirm `/health`, run at least
+one buffered and one streaming request with a low output limit, inspect errors
+and reservation settlement, and record the previous deployment identifier
+before promotion.
+
+Container automation publishes `2.0.1` and `latest` to both GHCR and Docker Hub
+only when the pushed Git tag is exactly `v2.0.1`, matching the Cargo package
+version, and that tag's commit is already contained in trusted `main`. Pull
+requests, `main` pushes, and manual workflow runs build and exercise the image
+but publish nothing, so they cannot overwrite a release image. The Docker build
+context is deny-by-default and contains only the Cargo manifest/lockfile, Rust
+source, policy schema, and pricing catalog. The release image records the exact
+version and source revision and runs as the fixed unprivileged identity
+`65532:65532`. Treat the version tag as immutable and pin the verified registry
+digest for deployment; do not use `latest` as a release identity.
+
+## Security boundaries
+
+- Provider and Noveum keys are secrets. Do not log them, commit them, embed them
+  in images, or pass them as command-line arguments.
+- The gateway accepts credentials in request headers. Terminate TLS before any
+  untrusted network and configure reverse proxies not to log sensitive headers.
+- `DEBUG_METRICS=true` emits request and response bodies. Use it for controlled
+  debugging, not general production logging of sensitive prompts.
+- Provider-specific `RUST_LOG=debug` targets can also emit request bodies,
+  responses, or streaming chunks. Keep production at `info`; enable debug only
+  briefly with non-sensitive traffic and protected log storage.
+- CORS is permissive. Browser exposure therefore requires an explicit
+  authentication and origin-control layer in front of the gateway.
+- Strict Nova Guard cost caps protect a policy budget; they are not a substitute
+  for provider quotas, AWS IAM, network access control, or billing alerts.
+
+## Contributing
+
+See
+[Contributing](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/CONTRIBUTING.md).
+Before opening a pull request, run the applicable checks in
+[Validation](https://github.com/Noveum/ai-gateway/blob/v2.0.1/docs/VALIDATION.md)
+and update the changelog for user-visible behavior.
+
+## License
+
+Dual-licensed under
+[MIT](https://github.com/Noveum/ai-gateway/blob/v2.0.1/LICENSE-MIT) or
+[Apache License 2.0](https://github.com/Noveum/ai-gateway/blob/v2.0.1/LICENSE-APACHE),
+at your option.

--- a/README.md
+++ b/README.md
@@ -64,11 +64,19 @@ for changes to
 
 ### 1. Install and start
 
-Rust 1.94.1 or newer is required.
+Rust 1.94.1 or newer is required. Choose the registry package after the release
+is published, or build a reviewed source checkout directly.
 
 ```bash
+# Registry installation (available after v2.0.1 is published)
 cargo install noveum-ai-gateway --version 2.0.1 --locked
 RUST_LOG=info noveum-ai-gateway
+```
+
+```bash
+# Reviewed source checkout (also works before registry publication)
+cargo build --release --locked
+RUST_LOG=info ./target/release/noveum-ai-gateway
 ```
 
 The native server listens on `http://127.0.0.1:3000` by default and honors

--- a/deny.toml
+++ b/deny.toml
@@ -26,20 +26,17 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # `unmaintained` and `unsound` both default to "workspace", which only looks at
 # our own direct dependencies. Both are widened to "all" so a problem that
 # arrives deep in the transitive tree still fails the build: that is exactly
-# where this kind of rot goes unnoticed. (Without this, RUSTSEC-2023-0086 below
-# is silently skipped.)
+# where this kind of rot goes unnoticed. Without this, a transitive soundness
+# advisory can be silently skipped.
 unmaintained = "all"
 unsound = "all"
 # A yanked dependency means the lockfile pins something the publisher pulled.
 yanked = "deny"
 
-# Waivers. Every entry needs a reason and a way out — an unexplained ID here
-# turns the gate into decoration. Neither of the two below has a fix that is
-# available today; both are tracked as follow-up work (NOV-102 follow-ups).
-ignore = [
-    { id = "RUSTSEC-2021-0141", reason = "dotenv 0.15.0 is unmaintained. It is a direct dependency (Cargo.toml, cfg(not(wasm32))) used only to load a .env file at startup; it parses a local, operator-supplied file, not untrusted input, and the advisory reports no vulnerability. The fix is to migrate to the maintained `dotenvy` fork, which is a near drop-in rename and touches src/ — deliberately out of scope for the lockfile/supply-chain change. FOLLOW-UP: migrate to dotenvy and delete this waiver." },
-    { id = "RUSTSEC-2023-0086", reason = "lexical-core 0.7.6 has multiple soundness issues, patched in >= 1.0.0. We do not depend on it directly: it arrives transitively via aws_event_stream_parser 0.1.2 -> nom 5.1.3, and nom only moved off lexical-core in 7.x. No upgrade of our own dependencies resolves it, so the real fix is replacing or forking aws_event_stream_parser (it is used for AWS Bedrock event-stream decoding). FOLLOW-UP: re-check when aws_event_stream_parser publishes a nom 7+ release, then delete this waiver." },
-]
+# No advisory waivers. Any future entry needs a documented reason, bounded
+# runtime scope, owner, and removal condition; an unexplained ID here turns the
+# gate into decoration.
+ignore = []
 
 [licenses]
 # Explicit allow-list derived from the actual dependency tree, not a template.

--- a/docs/CLOUDFLARE_DEPLOYMENT.md
+++ b/docs/CLOUDFLARE_DEPLOYMENT.md
@@ -1,6 +1,8 @@
 # Cloudflare deployment architecture
 
-Current as of **August 2026**.
+Applies to gateway **v2.0.1** (August 2026). The production evidence in this
+document is the dated v2.0.0 baseline; release preparation does not establish
+that v2.0.1 has been deployed or promoted.
 
 The repository ships two deployment shapes from the same Rust crate:
 
@@ -21,7 +23,12 @@ For operator commands and the platform-bridge runbook, use
 
 The Worker implementation includes:
 
-- `/health`, CORS, request-size limits, and `/v1/*` routing.
+- A static, no-JavaScript `GET /` information page with bodyless `HEAD /`
+  parity, `/health`, CORS, request-size limits, and `/v1/*` routing. `/docs` and
+  `/openapi.json` remain 404.
+- Explicitly disabled version-prefix and alias preview URLs. Release candidates
+  are attached at zero percent and exercised through Cloudflare's
+  version-override header before canary traffic.
 - Transparent proxying for the OpenAI-compatible provider routes.
 - Anthropic OpenAI Chat Completions ↔ Messages translation for requests,
   successful buffered responses, and successful SSE streams, including function
@@ -29,8 +36,11 @@ The Worker implementation includes:
   survive both response paths for settlement. Client function tools are
   supported; native Anthropic server/MCP tool definitions are not. The exact
   subset is documented in [providers/anthropic.md](providers/anthropic.md).
-- Bedrock Converse conversion and SigV4 signing in pure Rust (`sha2` + `hmac`),
-  including temporary credentials through `x-aws-session-token` on the Worker.
+- Buffered Bedrock Converse conversion and SigV4 signing in pure Rust (`sha2` +
+  `hmac`), including temporary credentials through `x-aws-session-token` on the
+  Worker. Worker `stream: true` is rejected with an OpenAI-shaped HTTP 400
+  `unsupported_feature` before admission/AWS; native ConverseStream remains
+  supported and now also accepts temporary credentials.
 - Inline stateless Nova Guard policies.
 - Dedicated platform-managed Nova Guard: effective policies, project **and
   organization** live counters, atomic admission, and reservation settlement.
@@ -38,21 +48,31 @@ The Worker implementation includes:
   through; successful Anthropic SSE is translated to OpenAI chunks before it is
   metered and returned.
 
-This document does not assert that the latest working tree is deployed on a
-production Cloudflare account. The reproducible PR evidence is:
+The v2.0.0 release was deployed to Cloudflare and verified on both
+`https://gate.noveum.ai` and its `workers.dev` hostname. The production service
+is intentionally **transparent**: it has no project-bound Noveum bridge because
+the hostname is shared. Dedicated bridge behavior was validated with isolated
+preview versions against the production control plane, including two projects
+sharing one organization counter, without assigning that preview project to all
+production callers.
+
+Release evidence has five layers:
 
 1. native formatting, lint, build, and hermetic tests;
 2. wasm compilation and `worker-build --release`;
 3. `wrangler deploy --dry-run`; and
 4. `scripts/novaguard_worker_e2e.sh`, a 13-phase suite running the generated
    bundle in real local `workerd` against mock Noveum, OpenAI, and Anthropic
-   upstreams.
+   upstreams; and
+5. an immutable Cloudflare preview and production promotion, followed by live
+   buffered/SSE checks through OpenAI, Anthropic, and Groq.
 
 The workerd suite covers `worker::Fetch`, policy/state/admission calls,
 `ctx.wait_until` settlement, incomplete streams, strict failure behavior,
 Anthropic tool-stream translation, mixed concurrent agents, and the matrix that
 selects which unbounded requests require a strict output limit. A real edge
-deployment and live-provider smoke test remain separate release activities.
+smoke remains mandatory for every new deployment; the v2.0.0 result is evidence
+for that immutable release, not for future working trees.
 
 ## Architecture
 
@@ -68,7 +88,7 @@ Cloudflare Worker (workerd / WASM)
   |-- provider adapter
   |     |-- OpenAI-compatible: transparent HTTP/SSE proxy
   |     |-- Anthropic: OpenAI request -> Messages; response/SSE -> OpenAI
-  |     `-- Bedrock: OpenAI request -> Converse + SigV4; response -> OpenAI
+  |     `-- Bedrock: OpenAI request -> buffered Converse + SigV4; response -> OpenAI
   |-- Nova Guard buffered output phase (streaming output phase is skipped)
   `-- reservation completion/abandon/cancel through ctx.wait_until
 ```
@@ -83,13 +103,13 @@ supplied per request. Platform-managed Nova Guard does require a scoped
 |---|---|---|
 | Outbound HTTP | `worker::Fetch` | `reqwest` |
 | Server runtime | `workerd` isolate | Tokio + Axum |
-| Bedrock signing | Pure Rust `sha2` + `hmac`; accepts optional session token | Native AWS signing path; session-token parity is tracked separately |
+| Bedrock signing | Pure Rust `sha2` + `hmac`; accepts optional session token | Native AWS SDK signer; accepts optional session token |
 | Caller tenancy | Dedicated project only; `NOVEUM_GUARD_TENANCY=shared` is refused with 503 | Dedicated or shared, with tenant derived from `x-noveum-api-key` |
 | Local policy source | Inline Worker var/secret; filesystem paths are unavailable | Inline JSON or file |
 | Stateful inline policy | Inline `cost_cap` / `rate_limit` is refused with 503 because it has no backend | Without platform state, stateful rules fail open and warn |
 | Platform state | Dedicated policy fetch, project/org counters, admission, settlement | Dedicated or per-derived-tenant clients |
 | Deployment-wide cost-mode override | Not implemented; each policy's `enforcementMode` decides | `NOVEUM_GUARD_COST_ENFORCEMENT=strict\|advisory` |
-| Streaming | OpenAI-compatible pass-through; Anthropic translated incrementally; no output-phase Guard enforcement | Same protocol-level behavior through the native transport |
+| Streaming | OpenAI-compatible pass-through; Anthropic translated incrementally; Bedrock rejected with HTTP 400 `unsupported_feature`; no output-phase Guard enforcement | OpenAI-compatible/Anthropic behavior plus Bedrock ConverseStream translation |
 | Telemetry export | No full native exporter; platform settlement is supported | Native telemetry plugins/exporters |
 
 ## Nova Guard correctness at the edge
@@ -190,32 +210,29 @@ Before deploying a release candidate:
 
 ```bash
 cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --lib
-cargo test --test novaguard_platform
-cargo test --test policy_integration
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --lib
+cargo test --locked --test novaguard_platform
+cargo test --locked --test policy_integration
+cargo check --locked --target wasm32-unknown-unknown --no-default-features --lib
 worker-build --release
 npx --yes wrangler@4.120.0 deploy --dry-run
 scripts/novaguard_worker_e2e.sh
 git diff --check
 ```
 
-Then perform an explicitly authorized staged deployment and smoke test with
-scoped credentials. At minimum verify `/health`, one buffered and one streaming
-OpenAI call, one buffered and one tool-streaming Anthropic call, an organization
-cap, a strict unbounded 400, and reservation settlement. Do not infer a live
-result from the hermetic suite.
+Then follow the explicitly authorized staged deployment and rollback runbook in
+[CLOUDFLARE_WORKER.md](CLOUDFLARE_WORKER.md#production-deployment-runbook).
+At minimum verify `/health`, one buffered and one streaming OpenAI call, one
+buffered and one tool-streaming Anthropic call, an organization cap, a strict
+unbounded 400, and reservation settlement. Do not infer a live result from the
+hermetic suite.
 
 ## Remaining work
 
-- Add a Worker-native telemetry sink (for example Analytics Engine or Queues).
-- Add Workers KV policy loading if globally distributed stateless bundles are a
-  requirement; this release reads Worker vars/secrets, not KV.
-- Re-enable `wasm-opt` after preserving panic recovery and bundle checks.
-- Decide whether the native Bedrock path should accept temporary credentials for
-  parity with the Worker.
-- Add an authorized staged-deployment smoke workflow if the organization wants a
-  repeatable live edge gate separate from hermetic PR CI.
+Worker-native telemetry, distributed policy storage, Bedrock feature expansion,
+and automated authorized smoke coverage are tracked in the [current
+roadmap](TODO.md). That roadmap is not a release promise.
 
 ## Primary sources
 

--- a/docs/CLOUDFLARE_WORKER.md
+++ b/docs/CLOUDFLARE_WORKER.md
@@ -8,7 +8,7 @@ transport and tenancy differences are called out below.
 | Shape | Build | Entry |
 |---|---|---|
 | Native binary / Docker | `cargo build --release` | `src/main.rs` (Axum + Tokio) |
-| Rust library | `noveum-ai-gateway` dep (rlib) | `lib.rs` |
+| Rust library | `noveum-ai-gateway` dependency (`rlib`) | `src/lib.rs` |
 | **Cloudflare Worker** | `worker-build --release` (`cargo … --target wasm32 --no-default-features`) | `src/worker_rt.rs` (`#[event(fetch)]`) |
 
 ## Prerequisites (one-time)
@@ -45,24 +45,25 @@ worker-build --release
 npx --yes wrangler@4.120.0 dev --port 8787
 ```
 
-Then exercise it exactly like the native gateway:
+Then exercise it exactly like the native gateway. A v2.0.1 source build reports
+that version:
 
 ```bash
 # Health
 curl localhost:8787/health
-# → {"status":"healthy","version":"1.2.0","runtime":"cloudflare-worker"}
+# → {"status":"healthy","version":"2.0.1","runtime":"cloudflare-worker"}
 
 # Proxy an OpenAI-compatible provider (x-provider + Bearer key, OpenAI body)
 curl localhost:8787/v1/chat/completions \
   -H "Authorization: Bearer $OPENAI_API_KEY" -H "x-provider: openai" \
   -H "Content-Type: application/json" \
-  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}],"max_tokens":32}'
 ```
 
 The checked-in `wrangler.toml` is deliberately transparent: it does not enable
 the commented SSN example or any other policy. Real-provider smoke tests require
-your own key; the PR gate and the end-to-end test below are hermetic and use no
-provider or Noveum credentials.
+your own key; CI and the end-to-end test below are hermetic and use no provider
+or Noveum credentials.
 
 ### Hermetic end-to-end proof of the platform bridge
 
@@ -105,24 +106,153 @@ the tee recovered 11 input / 4 output tokens from the terminal usage frame, so
 the hold is reconciled down by ~600x. Without the tee, every streamed request on
 the edge would bill at its ceiling.
 
-## Deploy to the global edge
+## Production deployment runbook
+
+Cloudflare separates a Worker **version** (code, bindings, and compatibility
+settings) from a **deployment** (the version or traffic split serving routes).
+Upload and test an immutable candidate before assigning production traffic.
+
+The v2.0.0 release was validated on `gate.noveum.ai` and its `workers.dev`
+hostname with buffered and SSE calls through OpenAI, Anthropic, and Groq.
+Production was deliberately deployed in transparent mode. This is evidence for
+that release, not permission to skip the following checks for a new version.
+
+### 1. Authenticate, build, and validate
 
 ```bash
-npx --yes wrangler@4.120.0 login          # authenticate to your Cloudflare account
-# Provider keys are passed PER REQUEST (Authorization header), so the Worker
-# itself needs no provider secrets. Set a stateless Nova Guard policy inline or
-# as a secret:
-#   - inline: edit NOVEUM_GUARD_POLICIES in wrangler.toml ([vars])
-#   - secret: npx --yes wrangler@4.120.0 secret put NOVEUM_GUARD_POLICIES
-npx --yes wrangler@4.120.0 deploy         # publish the Worker
+npx --yes wrangler@4.120.0 login
+npx --yes wrangler@4.120.0 whoami
+worker-build --release
+npx --yes wrangler@4.120.0 deploy --dry-run
+scripts/novaguard_worker_e2e.sh
 ```
 
-After deploy, the gateway answers at `https://noveum-ai-gateway.<account>.workers.dev`
-(or a custom route/domain) from the nearest PoP to each caller.
+Provider keys are passed per request and must not be Worker secrets. For a
+transparent shared hostname, confirm `wrangler.toml` has no Noveum project var
+and `wrangler secret list` has no `NOVEUM_API_KEY`. For a dedicated guarded
+Worker, configure the scoped bridge secret described below and verify that its
+fixed project is the only tenant this domain serves.
+
+### 2. Upload without production traffic
+
+```bash
+npx --yes wrangler@4.120.0 versions upload \
+  --tag v2.0.1-candidate \
+  --message "Noveum AI Gateway v2.0.1 candidate"
+npx --yes wrangler@4.120.0 versions list --json
+```
+
+Record the candidate version ID, export it in the operator shell, and inspect
+it before creating a deployment:
+
+```bash
+: "${CANDIDATE_VERSION_ID:?export the uploaded candidate version ID}"
+npx --yes wrangler@4.120.0 versions view "$CANDIDATE_VERSION_ID"
+```
+
+The checked-in `preview_urls = false` deliberately
+prevents [version-prefix and alias hostnames](https://developers.cloudflare.com/workers/versions-and-deployments/preview-urls/)
+from becoming public. Do not turn it on ad hoc for a production service; target
+the candidate through a zero-percent deployment and version override in the
+next step. Preview URLs that are intentionally enabled for another Worker must
+be protected with Cloudflare Access and removed after their bounded test
+campaign.
+
+### 3. Promote and observe
+
+First record the active deployment and its previous stable version. Attach the
+candidate at zero percent, then use Cloudflare's
+[version-override header](https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/)
+to exercise that exact version through the real custom domain without routing
+ordinary traffic to it:
+
+```bash
+: "${PREVIOUS_VERSION_ID:?export the recorded stable version ID}"
+: "${CANDIDATE_VERSION_ID:?export the uploaded candidate version ID}"
+npx --yes wrangler@4.120.0 deployments list
+npx --yes wrangler@4.120.0 versions deploy \
+  "${PREVIOUS_VERSION_ID}@100%" "${CANDIDATE_VERSION_ID}@0%" \
+  --message "Attach v2.0.1 for targeted smoke" -y
+
+curl --fail --silent https://gate.noveum.ai/health \
+  -H "Cloudflare-Workers-Version-Overrides: noveum-ai-gateway=\"${CANDIDATE_VERSION_ID}\""
+```
+
+With the same override header, verify `GET /`, bodyless `HEAD /`, `/health`, a
+bounded buffered request, and a bounded SSE request. Beginning with v2.0.1,
+`/` is a static no-JavaScript information page; `/docs` and `/openapi.json` are not
+API-documentation routes and remain 404. Confirm in logs that the override was
+applied; an invalid or not-yet-propagated override otherwise follows the normal
+traffic split.
+
+For a guarded candidate, also verify policy fetch/state, a successful strict
+admission, actual-usage settlement, a strict unbounded 400, organization scope,
+and zero leftover active test reservations. Use low-budget test credentials and
+remove temporary policies when finished.
+
+After the exact-version smoke passes, assign explicit canary percentages,
+observe, then promote the candidate to 100%:
+
+```bash
+: "${PREVIOUS_VERSION_ID:?export the recorded stable version ID}"
+: "${CANDIDATE_VERSION_ID:?export the uploaded candidate version ID}"
+npx --yes wrangler@4.120.0 versions deploy \
+  "${PREVIOUS_VERSION_ID}@90%" "${CANDIDATE_VERSION_ID}@10%" \
+  --message "Canary v2.0.1" -y
+
+npx --yes wrangler@4.120.0 versions deploy \
+  "${CANDIDATE_VERSION_ID}@100%" \
+  --message "Promote v2.0.1" -y
+```
+
+Check both the custom domain and `workers.dev` hostname. `/health` must report
+the promoted package version. Repeat buffered/SSE provider probes through the
+real production route and watch errors during the observation window:
+
+```bash
+curl --fail --silent https://gate.noveum.ai/health
+npx --yes wrangler@4.120.0 tail --status error
+```
+
+### 4. Roll back
+
+Rollback creates a new deployment immediately across all routes and domains.
+Use the exact stable version recorded before promotion:
+
+```bash
+: "${PREVIOUS_VERSION_ID:?export the recorded stable version ID}"
+npx --yes wrangler@4.120.0 rollback "$PREVIOUS_VERSION_ID" \
+  --message "Rollback failed gateway deployment"
+```
+
+After rollback, verify both health endpoints, repeat one buffered and one SSE
+call, and inspect errors. Do not delete the stable rollback version during
+candidate-version cleanup.
+
+### Observability
+
+`wrangler tail` provides real-time logs. For persistent Workers Logs, explicitly
+enable observability in `wrangler.toml`, choose a sampling rate appropriate for
+traffic and data sensitivity, and redeploy:
+
+```toml
+[observability]
+enabled = true
+head_sampling_rate = 0.1
+```
+
+Worker versions include configuration, so verify observability and bindings on
+the exact candidate. Alert on Worker exceptions, sustained 5xx, fail-closed
+admission outages, settlement retry exhaustion, and unexpected version skew.
+Cloudflare's [Workers Logs documentation](https://developers.cloudflare.com/workers/observability/logs/workers-logs/)
+describes retention and export options.
 
 ### Configuration (Worker `[vars]` / secrets)
 - The checked-in default is a **transparent proxy** — no policies, so nothing is
   mutated or blocked until you opt in.
+- `preview_urls = false` — version-prefix and alias preview hostnames remain
+  disabled even though the production `workers.dev` route is enabled. Candidate
+  smoke tests use a zero-percent deployment plus the version-override header.
 - `NOVEUM_GUARD_POLICIES` — inline `nova-guard.json` (same schema as the native
   `NOVEUM_GUARD_POLICIES`/file). Setting it activates stateless Nova Guard.
   Workers KV policy loading is not implemented in this release; use a Worker
@@ -151,9 +281,10 @@ After deploy, the gateway answers at `https://noveum-ai-gateway.<account>.worker
   reservation lease can be reaped while a Cloudflare stream is still connected.
 - `OPENAI_BASE_URL` — send `x-provider: openai` traffic to a compatible upstream
   instead of `api.openai.com`. The same override the native gateway honors, and
-  normalized by the same rule (trim, drop trailing slashes, reject empty). It is
-  what lets the Worker be tested against a local mock; in production leave it
-  unset.
+  normalized by the same rule (trim and drop trailing slashes); empty or
+  whitespace-only values are treated as unset and use the canonical default. It
+  is what lets the Worker be tested against a local mock; in production leave
+  it unset.
 - `ANTHROPIC_BASE_URL` — override the Anthropic upstream on the same terms; the
   Worker still appends `/v1/messages`. Leave unset in production unless the
   target is an Anthropic-compatible proxy.
@@ -218,6 +349,7 @@ conservative reservation estimate.
 | Configuration | Worker behavior |
 |---|---|
 | `NOVEUM_API_KEY` + `NOVEUM_GUARD_PROJECT_ID` set | **Platform-managed Nova Guard**, in dedicated mode. Policies, live state and admission come from the control plane; any inline `NOVEUM_GUARD_POLICIES` is ignored (with a warning) — the platform is the source of truth. |
+| `x-provider: bedrock` with `stream: true` | **400 `unsupported_feature` before admission or AWS dispatch.** The v2.0.1 Worker supports buffered Converse only; use the native gateway for ConverseStream. |
 | Applicable `mode: enforce`, `action: block`, `enforcementMode: strict` cost cap, but no positive explicit output limit | **400 `missing_output_limit`.** The Worker does not call `/admit` or the provider. Add `max_tokens`, `max_completion_tokens`, or `max_output_tokens`. |
 | Strict request supplies conflicting non-null output-limit aliases | **400 `unsupported_strict_input`.** The Worker does not reserve or forward a request whose admitted and upstream ceilings could differ. |
 | Advisory, shadow, or model-scoped-away cost cap; or `rate_limit` only | No strict output-limit rejection. When an estimate is needed, the Worker uses `NOVEUM_GUARD_ASSUMED_OUTPUT_TOKENS`. Cost/rate policy actions are `block`; use shadow mode or `softUsd` for nonblocking observation. |
@@ -244,18 +376,45 @@ allocate the isolate to death. Over the cap → **413**.
 
 **Enable the bridge**
 
+Do not use `wrangler secret put` for a production bridge change: that command
+creates a version and immediately deploys it. A key-only or project-only version
+is intentionally rejected by `/v1/*`, so sequential immediate mutations cause
+an avoidable outage. Instead, have the approved secret manager materialize a
+mode-`0600` JSON file outside the repository with both bindings:
+
+```json
+{
+  "NOVEUM_API_KEY": "replace-with-scoped-service-key",
+  "NOVEUM_GUARD_PROJECT_ID": "replace-with-dedicated-project-id"
+}
+```
+
+Create one **undeployed** version containing both secrets. Passing the project
+ID as a secret is allowed and makes the binding change atomic even though that
+identifier is not itself confidential:
+
 ```bash
-npx --yes wrangler@4.120.0 secret put NOVEUM_API_KEY
-# Paste a key with guardrails:read + guardrails:ingest.
-# NOVEUM_GUARD_PROJECT_ID is not a secret — put it in [vars] or:
-npx --yes wrangler@4.120.0 secret put NOVEUM_GUARD_PROJECT_ID
-npx --yes wrangler@4.120.0 deploy
+: "${NOVEUM_BRIDGE_SECRETS_FILE:?export the secure JSON file path}"
+npx --yes wrangler@4.120.0 versions secret bulk \
+  "$NOVEUM_BRIDGE_SECRETS_FILE" \
+  --tag novaguard-dedicated-enable \
+  --message "Stage dedicated Nova Guard bridge"
+npx --yes wrangler@4.120.0 versions list --json
 ```
 
 `NOVEUM_API_KEY` must be a **secret**, never a `[vars]` entry: `[vars]` is
-committed to `wrangler.toml` and readable in the dashboard. Both values are read
-with `env.secret()` first and `env.var()` as a fallback, so either mechanism
-works for the project id.
+committed to `wrangler.toml` and readable in the dashboard. Both values are
+read with `env.secret()` first and `env.var()` as a fallback, so using a secret
+for the project ID preserves the same runtime semantics. Record the new version
+as `CANDIDATE_VERSION_ID`, then follow the zero-percent override, guarded smoke,
+canary, and promotion process in [Promote and observe](#3-promote-and-observe).
+Only the final `versions deploy` step changes production traffic. Remove the
+local secrets file according to the secret manager's cleanup policy after the
+version is verified.
+
+Cloudflare documents that the ordinary secret commands deploy immediately,
+whereas the `versions secret` commands only create a version for later
+promotion; see [Workers secrets](https://developers.cloudflare.com/workers/configuration/secrets/).
 
 **Verify it is live**
 
@@ -275,20 +434,46 @@ name every admission block, fail-closed decision, and abandoned settlement.
 | Symptom | Cause | Action |
 |---|---|---|
 | Every `/v1/*` returns 503 `gateway_configuration_error` | Half-applied credentials, a blank secret, an inline `cost_cap`, or a malformed bundle — the message says which | Fix the named variable and redeploy. |
-| 503 naming "policy set could not be fetched" | The control plane is unreachable or the key is rejected | Check the key's scopes and `NOVEUM_API_URL`. To keep serving *unguarded* meanwhile: `npx --yes wrangler@4.120.0 secret put NOVEUM_GUARD_ALLOW_UNGUARDED_START` → `true`. Caps are NOT enforced while it is set — unset it as soon as the fetch recovers. |
+| 503 naming "policy set could not be fetched" | The control plane is unreachable or the key is rejected | Check the key's scopes and `NOVEUM_API_URL`. If an audited emergency decision permits unguarded traffic, stage `NOVEUM_GUARD_ALLOW_UNGUARDED_START=true` with `versions secret put` and the versioned promotion flow. The ordinary `secret put` command deploys immediately and is break-glass only. Caps are **not** enforced while the flag is set; stage its removal as soon as the fetch recovers. |
 | 400 with `error.code: "missing_output_limit"` | This model is covered by an enforcing/blocking strict cost cap and the request is unbounded | Send a positive `max_tokens`, `max_completion_tokens`, or `max_output_tokens`. Do not raise the assumed-output heuristic: strict mode deliberately refuses a heuristic bound. |
 | 400 `invalid_value` naming an output-limit field | The selected limit is zero, negative, non-integer, or above 10,000,000 | Correct the named field. The request was rejected before admission and provider dispatch. |
 | Anthropic 400 `invalid_request_error` naming `fallbacks`, `speed`, `inference_geo`, sampling, `cache_control`, thinking, or assistant prefill | The OpenAI-to-Messages adapter rejected an unsupported or unmeterable request shape | Follow the exact matrix in [the Anthropic provider guide](providers/anthropic.md). The Worker has not admitted the request or called Anthropic. |
 | Requests blocked with "platform admission unavailable … failing closed" | Admission returned 503 / exceeded its 2 s budget while a fail-closed strict cap is active | This is the policy working as written. Investigate the platform; setting the cap to fail-open trades enforcement for availability. |
-| Spend looks ~100x too high on streaming | `stream_options.include_usage` was stripped by something between the Worker and the provider, so streams settle at their estimate | Check `wrangler tail` for `abandon` settlements on streaming requests. |
+| OpenAI streaming spend remains near the reservation ceiling | `stream_options.include_usage` was stripped by something between the Worker and OpenAI, so the stream kept its estimate | Check `wrangler tail` for `abandon` settlement; Together and Fireworks use their provider-emitted terminal chunks instead of this option. |
 | `reservation … gave up after 3 attempts` in the logs | Settlement could not reach the platform | The hold expires server-side at `expiresAt` — conservatively, i.e. still counted until then. No action beyond fixing connectivity. |
 
-Removing the bridge means removing **both** values. Delete the API key with
-`npx --yes wrangler@4.120.0 secret delete NOVEUM_API_KEY`. If
-`NOVEUM_GUARD_PROJECT_ID` is also a secret, delete it with
-`npx --yes wrangler@4.120.0 secret delete NOVEUM_GUARD_PROJECT_ID`; if it is the
-usual `[vars]` entry, remove that entry from `wrangler.toml` and redeploy. During
-any half-applied interval the Worker deliberately returns 503.
+**Remove the bridge atomically**
+
+For the version-secret layout above, have the secret manager create a protected
+JSON file whose explicit `null` values delete both bindings. Omitted secrets are
+retained, so both names must be present:
+
+```json
+{
+  "NOVEUM_API_KEY": null,
+  "NOVEUM_GUARD_PROJECT_ID": null
+}
+```
+
+Wrangler 4.120.0 supports JSON `null` deletion. Create one undeployed removal
+version, record its ID, and use the same zero-percent override and promotion
+flow. The targeted smoke must show transparent provider routing and no Noveum
+control-plane calls before promotion:
+
+```bash
+: "${NOVEUM_BRIDGE_REMOVAL_FILE:?export the protected JSON file path}"
+npx --yes wrangler@4.120.0 versions secret bulk \
+  "$NOVEUM_BRIDGE_REMOVAL_FILE" \
+  --tag novaguard-dedicated-remove \
+  --message "Stage dedicated Nova Guard bridge removal"
+npx --yes wrangler@4.120.0 versions list --json
+```
+
+If a legacy deployment stores `NOVEUM_GUARD_PROJECT_ID` in `[vars]`, remove that
+entry in the same reviewed version that deletes the API-key secret; do not use
+sequential `wrangler secret delete` plus `wrangler deploy` commands. Verify the
+candidate contains neither binding before assigning traffic. At no point should
+a half-applied bridge version receive production traffic.
 
 ## Implemented edge behavior and verification scope
 
@@ -307,8 +492,8 @@ any half-applied interval the Worker deliberately returns 503.
   and error contract in [the Anthropic provider guide](providers/anthropic.md).
 - **Bedrock**: OpenAI → Bedrock **Converse** request, **AWS SigV4**-signed in pure
   Rust (`sha2`+`hmac`; see `src/sigv4.rs`) with credentials from `x-aws-*` headers,
-  and the Converse response converted back to OpenAI shape. Unlike native, the
-  edge also accepts **temporary credentials** via `x-aws-session-token`. Pass
+  and the Converse response converted back to OpenAI shape. Like native, the
+  edge accepts **temporary credentials** via `x-aws-session-token`. Pass
   `x-aws-access-key-id`, `x-aws-secret-access-key`, `x-aws-region` (+ optional
   `x-aws-session-token`) instead of `Authorization`:
 
@@ -320,6 +505,10 @@ any half-applied interval the Worker deliberately returns 503.
     -H "x-aws-region: us-east-1" -H "Content-Type: application/json" \
     -d '{"model":"amazon.nova-micro-v1:0","messages":[{"role":"user","content":"hi"}],"max_tokens":50}'
   ```
+  This Worker path is buffered only. `stream: true` returns an OpenAI-shaped
+  HTTP 400 with `error.code: "unsupported_feature"` before a Nova Guard
+  reservation or AWS request. The native gateway implements Bedrock
+  ConverseStream.
 - **SSE streaming**: OpenAI-compatible streams pass through unbuffered.
   Successful Anthropic streams are translated incrementally into OpenAI chunks;
   text, function tool calls, finish reason, terminal usage, and `[DONE]` are
@@ -355,16 +544,14 @@ The same Nova Guard policy schema, decisions, and redactions run here as on the
 native server (the engine + request/response shaping are one shared codebase).
 Note the redact replacement key is **`redactWith`** (see `wrangler.toml`).
 
-The PR's reproducible evidence is local/CI evidence: wasm compilation,
-`worker-build --release`, `wrangler deploy --dry-run`, native unit/integration
-tests, and the 13-phase hermetic `workerd` suite. That suite exercises actual
+The v2.0.0 release evidence includes wasm compilation, `worker-build --release`,
+`wrangler deploy --dry-run`, native unit/integration tests, the 13-phase
+hermetic `workerd` suite, dedicated guarded previews against the production
+control plane, and a transparent production deployment with live OpenAI,
+Anthropic, and Groq buffered/SSE probes. The hermetic suite exercises actual
 `worker::Fetch`, Anthropic translation, `ctx.wait_until`, concurrent agents,
-stream settlement, and strict-policy selection against mocks. It does **not**
-claim that this exact working tree has been published to or smoke-tested on a
-production Cloudflare account.
+stream settlement, and strict-policy selection against mocks. Future working
+trees need their own edge evidence.
 
-**Next (see [CLOUDFLARE_DEPLOYMENT.md](CLOUDFLARE_DEPLOYMENT.md)):**
-- Edge telemetry sink (Workers Analytics Engine / Queues) and Workers-KV policies.
-- Re-enable `wasm-opt` after preserving the panic-recovery bundle assertions.
-- Optionally add `x-aws-session-token` support to the **native** Bedrock path too
-  (the edge already supports temporary credentials).
+Known follow-up work is centralized in the [current roadmap](TODO.md); it is not
+a release promise.

--- a/docs/CLOUDFLARE_WORKER.md
+++ b/docs/CLOUDFLARE_WORKER.md
@@ -442,38 +442,54 @@ name every admission block, fail-closed decision, and abandoned settlement.
 | OpenAI streaming spend remains near the reservation ceiling | `stream_options.include_usage` was stripped by something between the Worker and OpenAI, so the stream kept its estimate | Check `wrangler tail` for `abandon` settlement; Together and Fireworks use their provider-emitted terminal chunks instead of this option. |
 | `reservation … gave up after 3 attempts` in the logs | Settlement could not reach the platform | The hold expires server-side at `expiresAt` — conservatively, i.e. still counted until then. No action beyond fixing connectivity. |
 
-**Remove the bridge atomically**
+**Remove the bridge with an atomic traffic cutover**
 
-For the version-secret layout above, have the secret manager create a protected
-JSON file whose explicit `null` values delete both bindings. Omitted secrets are
-retained, so both names must be present:
+Make the change atomic **to production traffic** by creating only undeployed
+versions until the final transparent version has been inspected. Wrangler
+4.120.0 preserves secrets during `versions upload`, while each
+`versions secret delete` command creates another undeployed version from the
+latest version, as described in Cloudflare's
+[secret-management reference](https://developers.cloudflare.com/workers/configuration/secrets/#delete-secrets-from-your-project).
+Serialize these commands under an operator lock—do not allow a concurrent
+upload to change what “latest” means.
 
-```json
-{
-  "NOVEUM_API_KEY": null,
-  "NOVEUM_GUARD_PROJECT_ID": null
-}
-```
-
-Wrangler 4.120.0 supports JSON `null` deletion. Create one undeployed removal
-version, record its ID, and use the same zero-percent override and promotion
-flow. The targeted smoke must show transparent provider routing and no Noveum
-control-plane calls before promotion:
+First, in the exact reviewed release checkout, remove any legacy
+`NOVEUM_GUARD_PROJECT_ID` entry from `[vars]`. Upload that configuration without
+`--keep-vars`; this removes the plain-text variable but deliberately inherits
+the secrets. Do not assign traffic to this intermediate version. Then delete
+each secret from the latest undeployed version:
 
 ```bash
-: "${NOVEUM_BRIDGE_REMOVAL_FILE:?export the protected JSON file path}"
-npx --yes wrangler@4.120.0 versions secret bulk \
-  "$NOVEUM_BRIDGE_REMOVAL_FILE" \
-  --tag novaguard-dedicated-remove \
-  --message "Stage dedicated Nova Guard bridge removal"
+npx --yes wrangler@4.120.0 versions upload \
+  --strict \
+  --tag novaguard-remove-config \
+  --message "Stage Nova Guard bridge variable removal"
 npx --yes wrangler@4.120.0 versions list --json
+: "${CONFIG_VERSION_ID:?export the just-uploaded configuration version ID}"
+npx --yes wrangler@4.120.0 versions view "$CONFIG_VERSION_ID"
+
+# Run each delete only when `versions view` identifies that name as a secret.
+npx --yes wrangler@4.120.0 versions secret delete NOVEUM_API_KEY \
+  --tag novaguard-remove-api-key \
+  --message "Stage Nova Guard API-key removal"
+npx --yes wrangler@4.120.0 versions secret delete NOVEUM_GUARD_PROJECT_ID \
+  --tag novaguard-remove-project \
+  --message "Stage Nova Guard project-secret removal"
+
+npx --yes wrangler@4.120.0 versions list --json
+: "${FINAL_VERSION_ID:?export the final removal version ID from the list}"
+npx --yes wrangler@4.120.0 versions view "$FINAL_VERSION_ID"
 ```
 
-If a legacy deployment stores `NOVEUM_GUARD_PROJECT_ID` in `[vars]`, remove that
-entry in the same reviewed version that deletes the API-key secret; do not use
-sequential `wrangler secret delete` plus `wrangler deploy` commands. Verify the
-candidate contains neither binding before assigning traffic. At no point should
-a half-applied bridge version receive production traffic.
+If a binding is not a secret in the inspected intermediate version, skip its
+`versions secret delete` command; it was removed with `[vars]`. The
+`--secrets-file` option is additive and cannot delete a secret, and
+`versions secret bulk` cannot remove a legacy `[vars]` entry, so neither is a
+one-command removal mechanism. Do not use the non-versioned `wrangler secret
+delete` command because it deploys immediately. Inspect the final version and
+verify that it contains neither binding before assigning traffic with the
+zero-percent override and promotion flow. Preview URLs must remain disabled,
+and no half-applied intermediate version may receive production traffic.
 
 ## Implemented edge behavior and verification scope
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,74 +1,78 @@
 # Contributing to Noveum AI Gateway
 
-Thank you for considering contributing to the Noveum AI Gateway! We welcome contributions from the community to help improve and expand the project. This document outlines the process for contributing and provides some guidelines to ensure a smooth collaboration.
+Contributions are welcome. Start with a GitHub issue or discussion when a
+change affects the public API, provider compatibility, policy behavior,
+pricing, tenancy, or deployment security; those contracts need agreement before
+implementation.
 
-## Getting Started
+## Set up
 
-1. **Familiarize Yourself with the Project**: 
-   - Read the [README.md](../README.md) to understand the project's purpose, features, and setup instructions.
-   - Explore the codebase to get a sense of the project's structure and coding style.
+The minimum supported Rust version is 1.94.1. Worker changes also require Node
+22+, the `wasm32-unknown-unknown` target, pinned `worker-build 0.8.5`, and
+Wrangler 4.120.0.
 
-2. **Check Open Issues**:
-   - Visit the [GitHub Issues](https://github.com/Noveum/ai-gateway/issues) page to see if there are any existing issues you can help with.
-   - Feel free to comment on issues if you need more information or want to express interest in working on them.
+```bash
+git clone https://github.com/Noveum/ai-gateway.git
+cd ai-gateway
+git switch -c feature/short-description
+cargo metadata --locked --format-version 1 >/dev/null
+cargo test --locked --lib
+```
 
-3. **Fork the Repository**:
-   - Create a fork of the repository to work on your changes.
+Read the [documentation index](README.md), the relevant provider/architecture
+guide, and [the v2 migration notes](MIGRATING_TO_V2.md) before changing a public
+type or behavior.
 
-4. **Clone Your Fork**:
-   - Clone your fork to your local machine using `git clone`.
+## Make the change
 
-## Making Changes
+- Keep provider behavior explicit. Do not claim upstream capabilities the
+  adapter does not translate or a live account has not verified.
+- Preserve transparent proxy compatibility unless a documented strict policy
+  contract requires a narrower request shape.
+- Fail visibly on guard configuration that would otherwise look enabled while
+  enforcing nothing.
+- Never add real credentials, `.env` files, production payloads, or secret
+  values to fixtures/logs.
+- Update `CHANGELOG.md` for user-visible behavior and link rather than
+  duplicating an existing authoritative guide.
+- Pricing changes start in `pricing/catalog.json`, must cite a primary provider
+  source, bump the catalog version, update every runtime mirror, and add exact
+  parity/boundary tests. See [Pricing](PRICING.md#updating-prices).
 
-1. **Create a Branch**:
-   - Create a new branch for your changes using `git checkout -b feature/your-feature-name`.
+## Validate
 
-2. **Write Clear, Concise, and Idiomatic Code**:
-   - Follow Rust's naming conventions and best practices.
-   - Ensure your code is modular and well-organized.
+Run the checks relevant to the change. The complete commands and live-test
+rules are in [Validation](VALIDATION.md). The minimum Rust gate is:
 
-3. **Test Your Code**:
-   - Write unit tests for new features or bug fixes.
-   - Run `cargo test` to ensure all tests pass.
+```bash
+cargo fmt --all -- --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --lib
+RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features
+git diff --check
+```
 
-4. **Document Your Changes**:
-   - Update documentation if your changes affect usage or setup.
-   - Add comments to your code where necessary for clarity.
+Worker changes also need the wasm check, pinned release bundle, Wrangler
+dry-run, and 13-phase workerd suite. A mocked test is not a claim that a paid
+provider or production deployment passed; record live coverage and omissions
+separately.
 
-## Future Work and Improvement Areas
+## Open the pull request
 
-Here are some areas where contributions would be particularly valuable:
+Include:
 
-1. **Implementing Prometheus Metrics Exporter**:
-   - Develop a well-tested Prometheus exporter for the telemetry system
-   - Implement appropriate metrics collection for AI request tracking
-   - Ensure compatibility with standard Prometheus monitoring setups
-   - Add documentation for Prometheus integration
+- the problem and intended user-visible outcome;
+- security, tenancy, pricing, and compatibility implications;
+- exact commands/results and the tested commit SHA;
+- live providers/runtimes tested, with explicit “not tested” entries;
+- rollout and rollback plan for deployment-affecting changes; and
+- documentation/changelog updates.
 
-2. **Additional Improvement Areas**:
-   - Performance optimizations for high-traffic deployments
-   - Support for additional AI providers
-   - Enhanced error handling and retry mechanisms
-   - Improved documentation and examples
+Keep the branch focused, address review feedback with tests where practical,
+and rerun exact-head checks after the final change.
 
-## Submitting a Pull Request
+## Releases and roadmap
 
-1. **Push Your Changes**:
-   - Push your branch to your fork using `git push origin feature/your-feature-name`.
-
-2. **Create a Pull Request**:
-   - Go to the original repository and click on "New Pull Request".
-   - Select your branch and provide a detailed description of your changes.
-
-3. **Be Detailed in Your PR Description**:
-   - Clearly explain the purpose of your changes.
-   - Reference any related issues or discussions.
-   - Include any relevant screenshots or logs if applicable.
-
-4. **Address Feedback**:
-   - Be responsive to feedback and make necessary changes.
-   - Engage in discussions to clarify any questions or concerns.
-
-## Thank You!
-
-Your contributions are greatly appreciated and help make Noveum AI Gateway better for everyone. We look forward to your input and collaboration! 
+Maintainers publish only reviewed, clean `main` commits using the immutable
+[release procedure](RELEASING.md). Candidate ideas belong in an issue; the
+[roadmap](TODO.md) lists known gaps but is not a release promise.

--- a/docs/MIGRATING_TO_V2.md
+++ b/docs/MIGRATING_TO_V2.md
@@ -1,0 +1,147 @@
+# Migrating from v1.2 to v2.0
+
+Noveum AI Gateway 2.0.0 is a SemVer-major release. Binary users can usually
+upgrade by replacing the executable and validating configuration. Rust library
+users must update three public APIs.
+
+Upgrade to the latest 2.0 patch available in your artifact channel. The public
+API changes were introduced in 2.0.0; version 2.0.1 adds post-release hardening
+without another API break.
+
+- [crates.io package](https://crates.io/crates/noveum-ai-gateway)
+- [docs.rs package](https://docs.rs/noveum-ai-gateway)
+- [GitHub releases](https://github.com/Noveum/ai-gateway/releases)
+- [v2.0.1 hardening notes](../CHANGELOG.md#201---2026-08-24)
+- [v2.0.0 breaking release notes](../CHANGELOG.md#200---2026-08-24)
+
+## Before upgrading
+
+1. Upgrade the toolchain to Rust **1.94.1** or newer.
+2. Record the current binary/image/Worker version so rollback has an exact
+   target.
+3. Inventory all `NOVEUM_GUARD_*` and `NOVEUM_*` settings. Empty or half-applied
+   bridge settings are errors in v2; do not rely on them being ignored.
+4. Decide whether the deployment is transparent, local-policy, dedicated, or
+   native shared tenancy. See [Configuration](configuration.md#choose-one-mode).
+5. If organization-scoped policies are enabled, deploy the Noveum control-plane
+   composite organization state support before the v2 gateway.
+
+## Dependency and MSRV
+
+Pin the major or exact version according to your update policy:
+
+```toml
+[dependencies]
+noveum-ai-gateway = "2"
+```
+
+Then update and verify the locked dependency graph:
+
+```bash
+cargo update -p noveum-ai-gateway --precise 2.0.1
+cargo check --locked --all-targets
+cargo test --locked
+```
+
+## Public API changes
+
+### `AppState::new` has four additional components
+
+The v1.2 constructor accepted configuration, metrics, and the policy engine.
+The v2 constructor also accepts the optional live-state provider, usage
+reporter, atomic-admission client, and shared-tenancy resolver:
+
+```rust
+let state = AppState::new(
+    config,
+    metrics,
+    policy,
+    None, // RemoteLiveState
+    None, // UsageReporter
+    None, // AdmissionClient
+    None, // SharedTenancy
+);
+```
+
+Passing four `None` values preserves a local/transparent embedding. Applications
+that enable the platform bridge should construct these components using the
+same validated configuration path as the binary; do not create only part of a
+bridge and assume the missing component will fail open.
+
+### `Policy::policy_type` preserves the wire value
+
+The field changed from `PolicyType` to `PolicyTypeTag`. Existing pattern matches
+must call `kind()`:
+
+```rust
+match policy.kind() {
+    PolicyType::RegexMatch => { /* ... */ }
+    other => { /* ... */ }
+}
+```
+
+Use `policy.type_name()` when reporting the exact value received in JSON. This
+is important for unknown or mistyped policy types: v2 can now report the
+operator's original string instead of collapsing it to `unknown`.
+
+Code that constructs a `Policy` directly can convert a known enum:
+
+```rust
+policy.policy_type = PolicyType::RegexMatch.into();
+```
+
+The serialized policy contract is unchanged: JSON still carries a string in
+the `type` field.
+
+### `PolicyEngine::from_env` now returns `Result`
+
+The function remains **asynchronous**. In v1.2 it returned `Self`; in v2 it
+returns `Result<Self, String>` so a configured but unreadable, malformed, or
+unenforceable bundle cannot silently become a pass-through engine:
+
+```rust
+let engine = PolicyEngine::from_env().await?;
+```
+
+If the surrounding error type is not compatible with `String`, map the error
+and abort startup. Do not replace the error with `PolicyEngine::disabled()` in
+production unless intentionally entering an emergency unguarded state.
+
+## Behavioral changes operators must validate
+
+- Platform-managed Nova Guard supports project and organization live state,
+  atomic strict admission, and reservation completion/cancel/abandon.
+- Native shared tenancy authenticates each request with `x-noveum-api-key` and
+  derives its project/organization server-side. The Cloudflare Worker refuses
+  shared tenancy.
+- An applicable enforcing/blocking strict cost cap requires a positive explicit
+  output limit. An unbounded request returns HTTP 400 `missing_output_limit`
+  before provider dispatch.
+- Unknown models are conservatively priced rather than treated as free. A
+  fail-closed cost cap can reject an unknown model.
+- Streaming responses are metered for settlement, but output-phase content
+  enforcement remains skipped for SSE in v2.0.x.
+- Local/inline stateful `cost_cap` and `rate_limit` policies still need the
+  platform bridge. The Worker refuses such an inline bundle because it has no
+  cross-request state backend.
+
+Review [Nova Guard](NOVA_GUARD.md) and [Pricing](PRICING.md) before enabling a
+hard budget.
+
+## Rollout and rollback
+
+1. Run the [validation checklist](VALIDATION.md) on the exact candidate.
+2. Deploy to a non-production endpoint or zero-traffic Worker version.
+3. Confirm `/health` reports the exact candidate version.
+4. Test one bounded buffered call and one bounded SSE call with low token
+   ceilings.
+5. For a guarded deployment, verify policy fetch, state scope, admission,
+   settlement, and no active reservation remains.
+6. Promote gradually where the runtime supports it and watch gateway, provider,
+   and control-plane errors.
+
+Rollback the deployment artifact, not just its configuration. Cloudflare
+operators should use the recorded previous immutable Worker version; native
+operators should restore the previous pinned image or binary. Re-run the same
+health and provider probes after rollback. A rollback does not erase usage or
+reservation records already written to the control plane.

--- a/docs/NOVA_GUARD.md
+++ b/docs/NOVA_GUARD.md
@@ -1,8 +1,10 @@
 # Nova Guard — Policy Enforcement in the Gateway
 
 Nova Guard is the policy-enforcement layer built into the Noveum AI Gateway. It
-inspects every LLM request and response flowing through the gateway and can
-**block**, **redact / mask**, or **flag** based on policies you define. It runs
+inspects JSON requests and buffered JSON responses and can **block**, **redact /
+mask**, or **flag** based on policies you define. Streaming requests still run
+input policies and usage metering, but streaming output content is not buffered
+for output-phase enforcement in v2.0.x. It runs
 the deterministic policy types entirely in-process (no network dependency), from
 a **local policy bundle** (file or inline env) — the gateway enforces guardrails
 standalone (BYOK mode) with no external service.
@@ -36,7 +38,7 @@ Policies can come from either of two places:
 
 | Env var | Default | Meaning |
 |---|---|---|
-| `NOVEUM_GUARD_ENABLED` | `true` | Master switch. `false`/`0` makes the gateway a pure pass-through. |
+| `NOVEUM_GUARD_ENABLED` | `true` | Master switch. A false value disables policy evaluation. A configured platform bridge may still initialize and report usage, so remove the bridge settings too when transparent mode is intended. |
 | `NOVEUM_GUARD_POLICIES_FILE` | _(unset)_ | Path to a `nova-guard.json` bundle. |
 | `NOVEUM_GUARD_POLICIES` | _(unset)_ | Inline JSON bundle (used if no file is set). |
 | `NOVEUM_GUARD_BLOCK_RESPONSE_MODE` | `synthetic_success` | `synthetic_success` (HTTP 200 with a refusal completion) or `provider_error` (HTTP 403 with the provider's error envelope). |
@@ -44,8 +46,8 @@ Policies can come from either of two places:
 | `NOVEUM_GUARD_ASSUMED_OUTPUT_TOKENS` | `1024` | Fallback completion estimate for advisory cost caps and rate-only admission. It is not a substitute for the explicit output limit required by an applicable enforcing/blocking strict cost cap. |
 
 When the engine is disabled or has zero active policies, the middleware
-short-circuits without buffering the body, so guardrails add **no overhead** when
-unused.
+short-circuits without buffering the body or evaluating rules. Normal gateway
+routing and telemetry still run.
 
 ## Policy bundle
 
@@ -77,11 +79,10 @@ The bundle format (`nova-guard.json`) is shared with the Nova Guard SDK:
       }
     },
     {
-      "name": "Monthly LLM budget",
-      "type": "cost_cap",
+      "name": "Bound prompt length",
+      "type": "token_length_cap",
       "mode": "enforce",
-      "failClosed": true,
-      "config": { "window": "1mo_calendar", "maxUsd": 1500, "action": "block" }
+      "config": { "phase": "input", "maxTokens": 100000, "action": "block" }
     }
   ]
 }
@@ -116,10 +117,12 @@ not call.
 
 A policy the engine cannot enforce is never silently skipped. It is logged at
 `error!` naming the policy and the reason, counted by
-`PolicyEngine::rejected_policies()`, and refuses startup when it came from a
-local bundle. If the policy is marked `failClosed`, it blocks traffic: a policy
-that can never compile can never be evaluated, which is exactly what
-`failClosed` is for. Shadow mode still never blocks.
+`PolicyEngine::rejected_policies()`, and refuses native startup when it came
+from a local bundle. A Worker inline bundle is evaluated per proxy request, so
+an invalid bundle returns a configuration error on `/v1/*` while `/` and
+`/health` can remain available. If the policy is marked `failClosed`, it blocks
+traffic: a policy that can never compile can never be evaluated, which is
+exactly what `failClosed` is for. Shadow mode still never blocks.
 
 | Type | Phase(s) | What it does |
 |---|---|---|
@@ -182,17 +185,24 @@ deployment serves more than one tenant.
 | `NOVEUM_API_URL` | optional | optional |
 | `NOVEUM_GUARD_TENANT_TTL_SECS` | n/a | optional, default `300` |
 | `NOVEUM_GUARD_TENANT_CACHE_MAX` | n/a | optional, default `1024` |
-| `NOVEUM_GUARD_POLICIES[_FILE]` | allowed | **refused at startup** |
+| `NOVEUM_GUARD_POLICIES[_FILE]` | not combined with the platform source; remove for clarity | **refused at startup** |
 
 Configuring both modes at once aborts startup rather than resolving by
 precedence, and shared mode is never inferred — it is only entered by asking
 for it, so an existing dedicated deployment cannot drift into it.
 
-**Dedicated** pins the whole process to one project. Every request a replica
+The Cloudflare Worker implements dedicated mode only. Do not attach one
+dedicated project to a hostname shared by unrelated callers: every call would
+be attributed and capped against that project. Keep that Worker transparent,
+deploy a dedicated Worker/domain per project, or use the native shared mode.
+
+**Dedicated** pins the whole deployment to one project. Every request a replica
 handles is metered and capped against it regardless of who sent it, which is
 correct for a gateway fronting one team and wrong for anything else. The policy
-set is fetched at startup (a failed first fetch aborts) and refreshed by a
-background poller.
+set is fetched before guarded traffic is allowed. Native refreshes it with a
+background poller; the Worker revalidates its per-isolate cache on requests. A
+failed first fetch refuses startup/native traffic or the Worker request unless
+the explicit emergency unguarded-start override is enabled.
 
 **Shared** authenticates each caller and derives its tenant server-side:
 
@@ -328,7 +338,8 @@ they reach the client, including function tool calls and terminal usage.
 
 Adding a new deterministic policy type is local:
 
-1. Add a variant to `PolicyType` (`src/policy/config.rs`) and a config struct.
+1. Add a variant to `PolicyType` (`src/policy/policy_types.rs`) and a config
+   struct.
 2. Implement `PolicyRule` in `src/policy/rules/<your_rule>.rs`.
 3. Add a `parse` arm in `compile_rule` (`src/policy/rules/mod.rs`).
 
@@ -337,21 +348,13 @@ no further changes.
 
 ## Cost / pricing
 
-Per-request cost is computed from the model pricing catalog in
-`pricing/catalog.json`, mirrored by hand into
-`src/policy/pricing_catalog.rs`, and used by `src/policy/pricing.rs`. The catalog
-version is `2026.08.23`; it includes provider-prefixed model ids, cache
-dimensions, tool fees, long-context tiers in both runtime mirrors, and supported
-request/response multipliers. Current OpenAI rows include GPT-5.6 Sol's $4/$20
-promotional Standard card, GPT-5.6 Cyber at $12.50/$75, and published GPT-5.6
-long-context cache rates. Current Anthropic
-rows include Sonnet 5 at the now
-permanent **$2 / million input** and **$10 / million output**, Opus 5 and the
-dated Opus 4.5 ID at $5/$25, and limited-availability Mythos 5 at $10/$50.
-Unknown models use the compiled runtime rows' derived $15/$75 maximum rather
-than $0. Missing billable
-dimensions use a conservative bound and mark the cost incomplete. A zero-output
-Anthropic pre-output refusal keeps token counts but settles at $0; partial-output
-refusals are billed normally. Rates remain policy estimates, not an invoice.
-See the [pricing guide](PRICING.md) and verify time-sensitive Anthropic values
-against [Anthropic's pricing page](https://platform.claude.com/docs/en/about-claude/pricing).
+Per-request cost is computed from the versioned manifest in
+`pricing/catalog.json`, mirrored into `src/policy/pricing_catalog.rs`, and used
+by `src/policy/pricing.rs`. Catalog membership is a pricing capability, not a
+claim that the caller's provider account can still invoke that model. Unknown
+models use the compiled runtime's conservative maximum rather than $0, and
+missing billable dimensions are bounded and marked incomplete. A zero-output
+Anthropic pre-output refusal keeps token counts but settles at $0;
+partial-output refusals are billed normally. Rates remain policy estimates, not
+an invoice. The catalog version, current rows, update procedure, and primary
+sources live in the single [pricing guide](PRICING.md).

--- a/docs/PR30_NOVAGUARD_REVIEW.md
+++ b/docs/PR30_NOVAGUARD_REVIEW.md
@@ -1,507 +1,125 @@
-# PR #30 NovaGuard release review
-
-**Review date:** 2026-08-23
-
-**Gateway PR:** [Noveum/ai-gateway#30](https://github.com/Noveum/ai-gateway/pull/30)
-
-**Gateway working branch:** `codex/pr30-release-blockers` (published to PR head
-`feat/novaguard-platform-bridge`)
-
-**Companion app PR:** [Noveum/noveum-app-nextjs#544](https://github.com/Noveum/noveum-app-nextjs/pull/544)
-
-**Companion app branch:** `codex/pr30-platform-guardrails`
-
-## Executive verdict
-
-The corrected local implementation is a **GO in the audited code scope**. No
-reproducible P0 or P1 correctness blocker remains in the frozen local tree.
-NovaGuard works end to end across the native gateway and a real local
-Cloudflare Workerd runtime, including atomic admission, strict cost limits,
-organization counters, request transforms, provider streaming, usage
-settlement, concurrency, and reservation cleanup.
-
-At the start of this blocker-fix pass, GitHub pointed at gateway commit
-`a0e93f8` and companion-app commit `5b7b14d`; their published checks were green,
-but they did not include the final Worker cache/configuration, pricing,
-model-scope-contract, and workflow-hardening changes described here. Approval
-should happen only after CI passes on both final pushed SHAs, the companion app
-is deployed first, and a fresh human/bot review is requested.
-
-Cloudflare compatibility is proven by WASM compilation, pinned
-`worker-build 0.8.5`, Wrangler `4.120.0 deploy --dry-run`, and the full 13-phase
-Workerd suite. A live Cloudflare deployment was intentionally not created, so
-this document does not claim production-edge deployment evidence.
-
-## What belongs in this PR
-
-### 1. Strict NovaGuard admission is now a real bounded contract
-
-Primary files:
-
-- `src/policy/middleware.rs`
-- `src/worker_rt.rs`
-- `src/routing.rs`
-- `src/policy/admission.rs`
-- `src/policy/admission_wire.rs`
-- `src/policy/worker_remote.rs`
-- `src/policy/engine.rs`
-- `tests/novaguard_platform.rs`
-- `scripts/novaguard_worker_e2e.sh`
-
-Required behavior now implemented:
-
-- Applicable `mode=enforce`, blocking, strict cost caps require a positive,
-  explicit output ceiling before `/admit`.
-- `max_tokens`, `max_completion_tokens`, and `max_output_tokens` are accepted;
-  multiple non-null aliases must agree.
-- The forwarded provider ceiling is the same ceiling reserved by NovaGuard.
-- Admission estimates the complete post-transform serialized JSON body, not
-  only visible message text. Function-tool schemas receive an additional
-  conservative reserve.
-- Input-transform expansion is measured after transformation and rechecked
-  against the 8 MiB body limit.
-- Strict mode rejects unbounded or externally expanded work before admission:
-  Responses/conversation state, malformed or non-JSON bodies, remote media,
-  file/audio/video/document inputs, server/MCP tools, provider search, premium
-  service tiers, Perplexity, and OpenRouter.
-- Advisory, shadow, and model-scope-miss cost policies are not accidentally
-  promoted to strict. When any stateful cost/rate policy is active, opaque or
-  malformed bodies are rejected because forwarding them without admission
-  would bypass the authoritative counters.
-- Provider-local deterministic validation and authentication errors happen
-  before a reservation is created.
-- Unknown providers are rejected before `/state`, `/admit`, or provider fetch.
-
-### 1a. Shared-gateway authorization and admission match the platform
-
-Primary gateway files:
-
-- `src/policy/remote.rs`
-- `src/policy/middleware.rs`
-- `src/policy/engine.rs`
-- `src/policy/admission_wire.rs`
-- `src/worker_rt.rs`
-
-Primary companion-app files:
-
-- `packages/api/src/routes/v1/projects/router.ts`
-- `packages/api/src/routes/v1/guardrails/schemas.ts`
-- `packages/api/src/routes/v1/guardrails/admission-handlers.ts`
-- `packages/billing/src/guardrails-admission.ts`
-
-The original shared runtime cached the first caller's authorization-bearing
-clients by organization/project and reused them for later API keys selecting
-the same tenant. The corrected runtime caches per-credential clients by a full
-SHA-256 identity, bounds rotated-key runtimes to 64 with idle/LRU eviction, and
-still shares one tenant-wide pending-spend ledger so two valid keys cannot spend
-the same advisory headroom.
-
-The gateway now resolves credentials through
-`GET /api/v1/projects/guardrails/resolve`. The companion endpoint requires all
-three permissions synchronously: `projects:read`, `guardrails:read`, and
-`guardrails:ingest`. A read-only key is rejected before any provider request,
-rather than being allowed while asynchronous usage ingestion fails later.
-
-The atomic admission wire now carries optional `forceStrictCostCaps`. Stored
-strict cost caps and every rate limit participate by default; the native strict
-deployment override forces all applicable cost caps. Cost model scopes are
-matched exactly and case-insensitively on both sides. Admission-outage handling
-uses the same policy selection, including rate-limit `failClosed` behavior.
-
-Strict mode deliberately favors an explicit 400 over a false “hard cap.” The
-broader provider surface remains available under advisory policies.
-
-### 2. Organization guardrails use organization counters
-
-Primary gateway files:
-
-- `src/policy/engine.rs`
-- `src/policy/remote.rs`
-- `src/policy/platform.rs`
-
-Primary platform files:
-
-- `packages/billing/src/guardrails-admission.ts`
-- `packages/api/src/routes/v1/guardrails/admission-handlers.ts`
-- `packages/api/tests/v1/guardrails-admission.integration.spec.ts`
-- `packages/api/tests/v1/guardrails-admission-model-scope.spec.ts`
-
-The gateway no longer substitutes project cost/rate windows when an
-organization-scoped policy needs organization state. Missing organization state
-uses unavailable/fail-closed semantics instead of silently enforcing the wrong
-counter. The platform admission path uses the policy source for the atomic
-counter key, and the companion patch filters `scopeToModels` by exact,
-case-insensitive model match before calculating reservation operations.
-
-The previously accepted but unimplemented `1d_calendar` window is now backed
-end to end. Redis admission and reads sum UTC-midnight through the current hour;
-the Postgres fallback sums from UTC midnight; both organization and project
-state expose the same key. The dashboard can create and edit this window.
-
-Production verification used two projects in the same organization. Their
-project counters remained distinct while the returned 30-day organization
-counter was identical. A real guarded GPT-5.6 Luna request increased the
-project, organization, and model counters by the same measured
-`$0.0000068`. This is the evidence needed to close the current organization
-counter review thread after the fixes are pushed.
-
-### 3. Anthropic is normalized on native and Worker paths
-
-Primary files:
-
-- `src/routing.rs`
-- `src/providers/anthropic.rs`
-- `src/providers/anthropic_stream.rs`
-- `src/worker_rt.rs`
-- `docs/providers/anthropic.md`
-
-The same shared transformer now drives native and Worker requests. It covers:
-
-- output-limit aliases and a deterministic default for non-strict requests;
-- ordered system/developer-message hoisting;
-- `stop` to `stop_sequences`;
-- OpenAI function tools, tool choice, parallel-tool control, assistant tool
-  calls, and tool results;
-- image data blocks supported by the compatibility contract;
-- sampling/model validation for current constrained Claude families;
-- Anthropic auth, `anthropic-beta`, safe custom headers, and query forwarding;
-- buffered tool calls and `finish_reason=tool_calls`;
-- fragmented Anthropic SSE, parallel tools, server/MCP deltas, exactly one
-  terminal chunk, `[DONE]`, and terminal usage;
-- cache read/write counters, server-tool counts, inference geography, speed,
-  and pre-output refusal semantics for settlement.
-
-Unsupported mixed-model `fallbacks`, native server/MCP tools, and unsupported
-premium shapes are rejected deterministically before admission rather than
-being forwarded and mispriced.
-
-This remains an OpenAI-shaped gateway contract. It does not claim wire-level
-compatibility with every Anthropic SDK response type.
-
-### 4. Pricing and settlement are billing-aware
-
-Primary files:
-
-- `src/policy/pricing.rs`
-- `src/policy/pricing_catalog.rs`
-- `pricing/catalog.json`
-- `src/policy/metering.rs`
-- `docs/PRICING.md`
-
-Catalog version `2026.08.23` now covers current model IDs, aliases, cache rates,
-long-context tiers, tool/search fees, and provider multipliers used by this PR.
-Request admission reserves declared cache/tool premiums, while completion uses
-provider-reported detailed usage. Important fixes include:
-
-- disjoint Anthropic 5-minute and 1-hour cache-write counters;
-- cache-read and cache-write rates, not ordinary input rates;
-- Anthropic US inference and supported fast-mode multipliers;
-- zero-cost pre-output Anthropic refusals, while mid-output refusals remain
-  billable;
-- exact xAI `usage.cost_in_usd_ticks` when present and hidden reasoning-token
-  fallback when it is absent;
-- conservative non-zero pricing for unknown models/dimensions;
-- no fabricated `0/0` usage when a provider reports only one token half;
-- GPT-5.6 long-context and cache tiers;
-- Bedrock Claude global versus geographic/direct pricing in both reservation
-  and settlement.
-
-Strict Bedrock admission accepts only catalogued commercial Claude model or
-system-profile IDs whose rate is derivable from the model ID. Amazon Nova,
-Titan, opaque application profiles, and non-commercial partition profiles stay
-available for advisory proxying but are rejected before strict admission until
-validated AWS source Region is part of the pricing contract. This is necessary
-because AWS's 2026-08-20 public price list, for example, prices Nova Pro in
-`eu-south-1` at `$1.28/$5.21` per million input/output tokens rather than the
-catalog's `$0.80/$3.20` global row.
-
-### 5. Cloudflare Worker parity and lifecycle safety
-
-Primary files:
-
-- `src/worker_rt.rs`
-- `src/policy/worker_remote.rs`
-- `scripts/novaguard_mock_platform.py`
-- `scripts/novaguard_worker_e2e.sh`
-- `docs/CLOUDFLARE_WORKER.md`
-- `docs/CLOUDFLARE_DEPLOYMENT.md`
-
-The Worker now has the platform policy/state/admission bridge, shared request
-normalization, provider-aware settlement, exact SSE scanning, and a ten-minute
-maximum admitted upstream lifetime. The deadline is intentionally below the
-platform's fifteen-minute reservation lease, so an active Worker stream cannot
-outlive and then lose its atomic hold to the platform reaper.
-
-The final Workerd run used 16 concurrent clients across four traffic classes:
-OpenAI buffered, OpenAI streaming, Anthropic buffered, and Anthropic streaming.
-It observed 16 new admissions, 16 provider calls, 16 completions, zero replay,
-zero cancellation, zero abandonment, zero HTTP errors, zero active holds, and
-`reservedUsd=0` after settlement. Peak provider concurrency was 16.
-
-### 6. Bedrock transport correctness
-
-Primary files:
-
-- `src/providers/bedrock.rs`
-- `src/proxy/mod.rs`
-- `src/routing.rs`
-- `docs/providers/bedrock.md`
-
-AWS EventStream content type is preserved until the Bedrock decoder sees it;
-binary messages are reassembled across arbitrary HTTP transport fragmentation,
-then emitted as valid, separately framed OpenAI SSE events. Bedrock tools and
-multimodal content are explicitly documented as unsupported by the current
-OpenAI-to-Converse adapter and are rejected in strict mode.
-
-### 7. Provider smoke CI actually starts the gateway
-
-Primary files:
-
-- `.github/workflows/provider-smoke.yml`
-- `tests/integration/common.rs`
-- `tests/integration/anthropic_test.rs`
-- `tests/integration/groq_test.rs`
-- `tests/integration/together_test.rs`
-- `tests/README.md`
-
-The workflow builds one locked gateway binary, starts it, polls `/health`, runs
-provider tests serially, and always cleans it up. Retired fixtures were replaced
-with active models: `claude-sonnet-5`, `openai/gpt-oss-20b`, and
-`meta-llama/Llama-3.3-70B-Instruct-Turbo`. Streaming assertions now require
-`[DONE]` while permitting valid tool-call-only streams.
-
-## Current model and price coverage
-
-The following standard rates are in both the Rust catalog and the companion
-TypeScript pricing table. Amounts are USD per one million tokens.
-
-| Provider | Model | Input | Output | Cache read | Cache write | 1h cache write |
-|---|---:|---:|---:|---:|---:|---:|
-| OpenAI | `gpt-5.6-luna` | $0.20 | $1.20 | $0.02 | $0.25 | — |
-| OpenAI | `gpt-5.6-terra` | $2.00 | $12.00 | $0.20 | $2.50 | — |
-| OpenAI | `gpt-5.6-sol` | $4.00 | $20.00 | $0.40 | $5.00 | — |
-| OpenAI | `gpt-5.6-cyber` | $12.50 | $75.00 | $1.25 | $15.625 | — |
-| Anthropic | `claude-sonnet-5` | $2.00 | $10.00 | $0.20 | $2.50 | $4.00 |
-| Anthropic | `claude-opus-5` | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
-| Anthropic | `claude-fable-5` | $10.00 | $50.00 | $1.00 | $12.50 | $20.00 |
-| Anthropic | `claude-mythos-5` | $10.00 | $50.00 | $1.00 | $12.50 | $20.00 |
-
-Aliases include `gpt-5.6 -> gpt-5.6-sol`,
-`daybreak-blue-latest -> gpt-5.6-sol`, and
-`daybreak-red-latest -> gpt-5.6-cyber`.
-
-OpenAI states that Sol's Standard promotion is available at least through
-November 21, 2026. Because it gives neither an exact end date nor replacement
-rates, the catalog has no speculative rollback schedule.
-
-Anthropic's current first-party pricing page and release notes state that
-Sonnet 5's `$2/$10` rate became the standard rate and the previously planned
-September 1 increase will not occur. There is intentionally no scheduled
-Sonnet 5 increase in this catalog.
-
-Primary sources:
-
-- [OpenAI API pricing](https://developers.openai.com/api/docs/pricing)
-- [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing)
-- [Anthropic release notes](https://platform.claude.com/docs/en/release-notes/overview)
-- [AWS Bedrock pricing](https://aws.amazon.com/bedrock/pricing/)
-- [AWS public Bedrock price list](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrock/current/index.json)
-
-## Cost calculation examples
-
-The token portion of a call is:
-
-```text
-uncached_input_tokens * input_rate / 1,000,000
-+ cache_read_tokens * cache_read_rate / 1,000,000
-+ 5m_cache_write_tokens * 5m_write_rate / 1,000,000
-+ 1h_cache_write_tokens * 1h_write_rate / 1,000,000
-+ output_tokens * output_rate / 1,000,000
-+ priced tool/search request fees
-```
-
-Provider multipliers are then applied to the dimensions covered by that
-provider's contract. An authoritative provider-reported total, such as xAI
-cost ticks, wins over catalog reconstruction.
-
-Real-key examples observed during this review:
-
-| Call | Calculation | Cost |
-|---|---:|---:|
-| GPT-5.6 Luna, 10 input + 4 output | `10*$0.20/M + 4*$1.20/M` | `$0.0000068` |
-| GPT-5.6 Terra, 10 input + 4 output | `10*$2/M + 4*$12/M` | `$0.000068` |
-| GPT-5.6 Sol, 10 input + 4 output | `10*$4/M + 4*$20/M` | `$0.00012` |
-| Sonnet 5 forced tool, buffered, 604 input + 35 output | `604*$2/M + 35*$10/M` | `$0.001558` |
-
-The production organization-counter probe used the Luna call and observed the
-same `$0.0000068` increment at project, organization, and model scope.
-
-## Verification ledger
-
-### Final frozen gateway tree
+# Archived v2.0.0 Nova Guard release validation
+
+> Historical record — not a current runbook.
+>
+> This file preserves the final evidence for gateway pull request
+> [#30](https://github.com/Noveum/ai-gateway/pull/30). The pull request is merged,
+> v2.0.0 is published, and the earlier pre-merge “pending” report has been
+> retired. Use [Validation](VALIDATION.md) for a new candidate and
+> [Cloudflare Worker operations](CLOUDFLARE_WORKER.md) for current deployment
+> instructions.
+
+## Final release identity
+
+| Artifact | Final value |
+|---|---|
+| Gateway pull request | [Noveum/ai-gateway #30](https://github.com/Noveum/ai-gateway/pull/30), merged |
+| Gateway merge commit / v2.0.0 tag | `8a631c93a45f300950ac80c9b7230ce6debff3ff` |
+| Companion control-plane pull request | Private Noveum app PR #544, merged and deployed |
+| Companion merge commit | `eb866ffcab04edf11a4947e4a55339dcb5031b2f` |
+| Crate | [noveum-ai-gateway 2.0.0](https://crates.io/crates/noveum-ai-gateway/2.0.0) |
+| Rust documentation | [docs.rs 2.0.0](https://docs.rs/noveum-ai-gateway/2.0.0/noveum_ai_gateway/) |
+| GitHub release | [v2.0.0](https://github.com/Noveum/ai-gateway/releases/tag/v2.0.0) |
+
+## What was released
+
+- Platform-managed Nova Guard on native and Cloudflare runtimes: effective
+  policy fetch, live project/organization state, atomic strict admission, and
+  complete/cancel/abandon reservation settlement.
+- Native dedicated and shared tenancy. Shared mode derives tenant identity from
+  each caller's scoped Noveum credential and refuses unentitled routing headers.
+- Organization policies evaluate organization counters; project state is never
+  substituted when organization state is absent.
+- A versioned policy schema and named rejections for malformed, unknown,
+  reserved-but-unenforceable, and invalid-source policies.
+- Strict cost-cap bounds, provider-aware request preflight, conservative unknown
+  pricing, authoritative usage settlement, and a versioned pricing catalog.
+- Worker cache/refresh ordering, lease-safe timeouts, Anthropic buffered/SSE
+  translation, and the 13-phase hermetic workerd regression suite.
+
+The release is SemVer-major because `AppState::new`, `Policy::policy_type`, and
+the error return of asynchronous `PolicyEngine::from_env` changed. See the
+[migration guide](MIGRATING_TO_V2.md).
+
+## Final automated evidence
+
+The exact release candidate passed:
 
 | Gate | Result |
 |---|---|
-| Rust library tests | **486 passed, 0 failed** |
-| NovaGuard platform integration | **61 passed, 0 failed** |
-| Policy integration | **12 passed, 0 failed** |
-| Clippy, all targets/features, warnings denied | **Passed** |
-| Rust formatting and `git diff --check` | **Passed** |
-| All-target test compilation | **Passed** |
-| `wasm32-unknown-unknown`, no native defaults | **Passed** |
-| `worker-build 0.8.5 --release` | **Passed** |
-| Wrangler `4.120.0 deploy --dry-run` | **Passed** |
-| RustSec audit, with repository allowlist | **Passed** |
-| 13-phase pinned Workerd E2E | **Passed** |
+| Rust library tests | 499 passed, 0 failed |
+| Platform integration | 61 passed, 0 failed |
+| Policy integration | 12 passed, 0 failed |
+| Provider harness helpers | 3 passed, 0 failed |
+| Formatting and strict Clippy | passed |
+| Rustdoc with warnings denied | passed |
+| Locked Cargo package/publish dry-run | passed |
+| wasm32 check and pinned `worker-build 0.8.5` | passed |
+| Wrangler `4.120.0 deploy --dry-run` | passed |
+| 13-phase workerd bridge suite | passed |
+| Docker and supply-chain CI | passed |
 
-The Workerd matrix additionally proved:
+All 42 actionable review threads were resolved before merge. The final Worker
+control-plane request path sends a stable versioned `User-Agent`; this was
+required because the production CloudFront managed WAF correctly rejected
+missing-user-agent subrequests. The WAF was not weakened.
 
-- OpenAI and Anthropic buffered/stream settlement;
-- Anthropic tools, auth, headers, query and body conversion;
-- strict/advisory/shadow/model-scope policy selection;
-- transformed-body and tool-schema reservation;
-- pre-admission rejection for xAI search, Bedrock Nova, conflicting output
-  aliases, Groq Compound, Gemini search/cached context, Mistral documents,
-  Together video, media, MCP, Perplexity, OpenRouter, and unpriced custom bases;
-- 16-way multi-agent concurrency with no duplicate settlement or leaked hold;
-- rate-only opaque-input rejection and `/admit`-503 fail-closed/fail-open parity;
-- Worker deadline abandonment before lease expiry, followed by a successful new
-  admission with zero reservation reaping;
-- request-scoped `NOVEUM_GUARD_ASSUMED_OUTPUT_TOKENS=128000` parity between
-  `/admit` and the Anthropic `max_tokens` forwarded upstream;
-- binding-only policy-engine recompilation and monotonic cache replacement, so
-  an unchanged ETag or a delayed older refresh cannot restore stale enforcement.
+## Control-plane and organization-scope proof
 
-### Companion Noveum app tree
+After companion PR #544 deployed, production probes created temporary
+shadow/strict policies and two projects in one organization. A request in each
+project incremented separate project counters while both reads returned the
+same aggregate nested organization counter. Cancelling both reservations
+restored project and organization state, and the temporary policy was deleted.
 
-- API unit suite: **738 passed**, 29 integration-mode skips (the 27 Redis
-  guardrail cases below were run separately against a real Redis instance).
-- Real Redis guardrail integrations: **27/27 passed**.
-- Web suite: **391/391 passed**.
-- Telemetry suite: **136/136 passed**.
-- Focused guardrail/project router suite: **72/72 passed**.
-- API, web, and telemetry TypeScript checks: **Passed**.
-- Translation parity/usage, schema parity, Biome, comments, and diff checks:
-  **Passed**.
+A separate `1d_calendar` probe admitted and accounted a bounded call, then
+cancelled it and restored both scopes to zero. Policy model scoping was
+confirmed as applicability filtering, not as a second spend ledger.
 
-The app patch additionally preserves `enforcementMode` and `scopeToModels`
-through dashboard load/edit/save, adds a strict/advisory selector and model list,
-makes dry-run model-aware, and hardens pricing lookup against inherited object
-keys such as `__proto__` and `constructor`.
+## Real runtime proof
 
-### Live provider and production checks
+### Native gateway
 
-Final real-key runs read only the required credential names with a narrow
-parser, and no secret value is reproduced here. See the security note below for
-the one early diagnostic that did not follow this rule.
+With real provider credentials supplied from an unprinted environment file,
+OpenAI, Anthropic, and Groq each passed one buffered and one streaming call:
+six calls, six HTTP successes. The runtime startup banner and `/health`
+reported v2.0.0.
 
-- OpenAI GPT-5.6 Luna: buffered and streaming passed.
-- Anthropic Sonnet 5: buffered, streaming, buffered tool call, and streaming
-  tool call passed with usage/cost parity.
-- Groq: buffered and streaming passed.
-- Noveum production guard state and guarded usage: passed across two projects.
-- Together, Fireworks, and AWS Bedrock did not have usable credentials in the
-  available environment, so no claim of paid live coverage is made for them.
-- No live Cloudflare deployment was made; Workerd and Wrangler dry-run are the
-  deployment evidence for this review.
+### Cloudflare
 
-## Dependency and toolchain decision
+Dedicated guarded preview versions exercised the real Worker runtime against
+the production Noveum control plane without changing production traffic. The
+tests covered policy fetch, state, strict admission, provider dispatch,
+settlement, two-project organization aggregation, and cleanup.
 
-The published branch already contains the required transitive security update
-from vulnerable `h2 0.4.15` to fixed `h2 0.4.16`; fresh `cargo audit` and
-`cargo deny` scans pass. No broader library upgrade is needed. The locked Worker stack is
-coherent: `worker`, `worker-macros`, and `worker-sys 0.8.5`,
-`wasm-bindgen 0.2.126`, `worker-build 0.8.5`, Wrangler `4.120.0`, and Node 22 in
-CI. The final local Workerd run used Node `25.5.0` and Rust `1.96.0` without a
-runtime issue. `Cargo.toml` now advertises the actual AWS dependency MSRV,
-Rust `1.94.1`.
+Production was then deployed to `https://gate.noveum.ai` and the service's
+`workers.dev` hostname in **transparent** mode. This was intentional: a
+project-bound dedicated bridge on a hostname shared by callers would attribute
+all traffic to one project. Both domains reported healthy v2.0.0, real OpenAI,
+Anthropic, and Groq buffered/SSE probes passed, and the observation window had
+no Worker errors. At the 2026-08-24 verification point, Cloudflare routed 100%
+of production traffic to version v57 and version v49 was retained as the
+recorded rollback target.
 
-An old machine-global `worker-build 0.1.2` produced the wrong output layout in
-one diagnostic dry-run. Prepending the pinned `0.8.5` binary—the same setup used
-by CI and the Workerd harness—made the dry-run pass. Upgrading repository pins
-to work around a stale global installation would reduce reproducibility.
+As post-release cleanup, the authorized preview versions v50–v56 were deleted.
+Follow-up requests to their version-prefix and alias hostnames returned 404,
+and Cloudflare's GraphQL analytics showed no executions for the deleted
+versions during the verification window. Version-prefix and alias preview URLs
+are now disabled in `wrangler.toml` so a future upload does not silently restore
+that exposure.
 
-## GitHub review state
+## Scope not claimed
 
-At the last authoritative refresh:
+- No v2.0.0 release claim was made for a paid live Fireworks, Together, or AWS
+  Bedrock request. Their routing/conversion paths had hermetic coverage; live
+  execution requires an available key, Region/model entitlement, and a bounded
+  cost authorization.
+- Streaming output content was not subject to output-phase Nova Guard
+  enforcement. Input policies and terminal usage settlement still ran.
+- The production shared Cloudflare hostname did not enable platform-managed
+  guardrails. Guarded Cloudflare tenancy remained dedicated-only.
+- Worker-native persistent telemetry and Workers KV policy loading were not
+  part of v2.0.0.
 
-- Gateway PR #30 was open, non-draft and mergeable, with no approval decision.
-- Companion app PR #544 was open, non-draft and mergeable, with no approval
-  decision.
-- Gateway native, Worker, supply-chain, Docker, and CodeRabbit status checks
-  were green on `a0e93f8`. None of those checks covers this final local release
-  patch.
-- CodeRabbit's summary explicitly said reviews were paused after the commit
-  influx; its green check is not a fresh review of this local tree.
-- There were 29 review threads: 19 resolved and 10 open.
-- Nine open threads were outdated and are addressed by the local implementation.
-- The one open/current organization-counter thread can be answered with the
-  two-project production evidence after the relevant code is pushed/deployed.
-
-Do not resolve or reply to those threads against the old remote SHA. Push first,
-run fresh checks, then reply with the exact test/evidence references.
-
-## Required merge sequence
-
-1. Commit and push both release branches and link PR #30 to companion PR #544.
-2. Run all GitHub checks and request fresh review on both pushed SHAs.
-3. Merge/deploy the app-side change **before** the gateway. The new gateway
-   resolver intentionally fails closed until the companion endpoint exists.
-   Confirm
-   the production `/state` and `/admit` paths still expose source-keyed
-   organization counters and model-scoped operations.
-4. Run the provider-smoke workflow and a two-key/same-tenant plus
-   two-project/one-organization production probe after the app deploy.
-5. Run a live Cloudflare staging deployment if production-edge evidence is a
-   release requirement.
-6. Request a fresh human and CodeRabbit review.
-7. Reply to and resolve the nine stale fixed threads. Close the organization
-   thread only with the pushed SHA and production two-project evidence.
-8. Approve and merge only after all checks above are green.
-
-## Work deliberately deferred to follow-up PRs
-
-These are documented limitations, not hidden blockers in the strict surface
-implemented here:
-
-- strict support for `/v1/responses`, multipart endpoints, audio/files/images,
-  provider search, Perplexity/OpenRouter request fees, and arbitrary server
-  tools;
-- region-aware Bedrock Nova/Titan admission and settlement, including AWS
-  partition-specific rate tables;
-- Bedrock OpenAI tool-call and multimodal translation;
-- exact model tokenizers and image-dimension accounting instead of the current
-  conservative serialized-byte bound;
-- mixed-model Anthropic fallback settlement;
-- Cloudflare shared-tenancy mode (currently refused rather than silently
-  mis-enforced);
-- native Bedrock temporary-session credential parity;
-- a repository-local Node lock for Wrangler and a dedicated minimum-Rust CI
-  lane;
-- paid live Together, Fireworks, Bedrock, and a live Cloudflare staging matrix.
-- exact audit persistence for gateway `pricingVersion` and `costBreakdown`;
-- metering ownership for requests spanning advisory/strict policy hot swaps;
-- graceful-shutdown draining of detached exporters and shared tenant reporters;
-- Worker policy-refresh timeout and singleflight (the implemented monotonic
-  generation guard prevents a delayed older refresh from replacing newer state
-  but does not coalesce concurrent fetches);
-- cross-replica atomic admission for native rate-only policies (current native
-  rate enforcement remains advisory and may overshoot during refresh windows).
-
-## Security/operations note
-
-During one early read-only environment inspection, a reviewer initially used
-shell sourcing on an app `.env`; a malformed/unquoted line caused an opaque
-secret-looking value to appear in the internal command trace. The value is not
-reproduced here and subsequent access used a narrow parser. If internal command
-traces are retained outside the normal trusted development boundary, rotate the
-credential associated with that malformed line as a precaution. Never source
-the app `.env` in test automation.
-
-## Final decision
-
-**Local corrected implementation:** GO.
-
-**GitHub PR at its currently published SHA:** NO-GO until the local patches and
-companion app changes are pushed, deployed in the required order, and pass fresh
-CI/review.
+These are explicit product boundaries, not hidden passes. Re-evaluate them for
+each later release using [Validation](VALIDATION.md).

--- a/docs/PRICING.md
+++ b/docs/PRICING.md
@@ -167,16 +167,19 @@ available **at least through November 21, 2026**. It has not published an exact
 end date or replacement rates, so the catalog carries the promotion as the
 current rate and intentionally has no scheduled rollback.
 
-### Current Anthropic rows
+### Selected Anthropic catalog rows
 
-| Model | Availability note | Input | Output | Cache hit | 5m write | 1h write |
+These are selected non-legacy pricing rows, not an inventory of models enabled
+for a particular Anthropic account. Verify model availability separately.
+
+| Model | Catalog note | Input | Output | Cache hit | 5m write | 1h write |
 |---|---|---:|---:|---:|---:|---:|
-| `claude-sonnet-5` | Active; $2/$10 launch pricing is permanent | $2.00 | $10.00 | $0.20 | $2.50 | $4.00 |
-| `claude-opus-5` | Active | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
-| `claude-opus-4-8` | Active | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
-| `claude-opus-4-5-20251101` | Active dated model ID | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
-| `claude-fable-5` | Active | $10.00 | $50.00 | $1.00 | $12.50 | $20.00 |
-| `claude-mythos-5` | Active, limited/invitation-only availability | $10.00 | $50.00 | $1.00 | $12.50 | $20.00 |
+| `claude-sonnet-5` | Non-legacy row; no scheduled increase | $2.00 | $10.00 | $0.20 | $2.50 | $4.00 |
+| `claude-opus-5` | Non-legacy row | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
+| `claude-opus-4-8` | Non-legacy row | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
+| `claude-opus-4-5-20251101` | Non-legacy dated row | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
+| `claude-fable-5` | Non-legacy row | $10.00 | $50.00 | $1.00 | $12.50 | $20.00 |
+| `claude-mythos-5` | Non-legacy row | $10.00 | $50.00 | $1.00 | $12.50 | $20.00 |
 
 Anthropic publishes cache hits at 0.1x input, 5-minute writes at 1.25x,
 1-hour writes at 2x, US-only inference at 1.1x for eligible models, and fast

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,46 @@
+# Noveum AI Gateway documentation
+
+Start with the page that matches what you are trying to do.
+
+## Use the gateway
+
+- [Five-minute quick start](../README.md#five-minute-quick-start)
+- [Configuration and credential roles](configuration.md)
+- [Nova Guard policies and tenancy](NOVA_GUARD.md)
+- [Pricing and cost accounting](PRICING.md)
+- [Telemetry and sensitive-data handling](logs.md)
+
+## Upgrade, deploy, and operate
+
+- [Migrate from v1.2 to v2](MIGRATING_TO_V2.md)
+- [Native, Docker, and Kubernetes deployment](deployment.md)
+- [Cloudflare Worker runbook](CLOUDFLARE_WORKER.md)
+- [Cloudflare runtime architecture](CLOUDFLARE_DEPLOYMENT.md)
+- [Validation checklist](VALIDATION.md)
+- [Release procedure](RELEASING.md)
+
+## Providers
+
+- [OpenAI](providers/openai.md)
+- [Anthropic](providers/anthropic.md)
+- [Groq](providers/groq.md)
+- [Fireworks](providers/fireworks.md)
+- [Together AI](providers/together.md)
+- [AWS Bedrock](providers/bedrock.md)
+- [Mistral, Cohere, Gemini, DeepSeek, xAI, OpenRouter, and Perplexity](providers/openai-compatible.md)
+
+Provider model availability changes independently of gateway releases. The
+provider's own model catalog is the source of truth for whether a model can be
+called; [`pricing/catalog.json`](../pricing/catalog.json) is the source of truth
+for what this gateway version can estimate.
+
+## Develop and contribute
+
+- [Contributing](CONTRIBUTING.md)
+- [Telemetry exporter interface](telemetry-plugins.md)
+- [Current roadmap](TODO.md)
+- [Changelog](../CHANGELOG.md)
+- [Rust API documentation](https://docs.rs/noveum-ai-gateway)
+
+[The v2.0.0 PR 30 validation record](PR30_NOVAGUARD_REVIEW.md) is archived, not
+a current runbook. Use [Validation](VALIDATION.md) for repeatable checks.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,115 @@
+# Release procedure
+
+This runbook is for maintainers publishing the Rust crate and matching GitHub
+release. A crates.io version is immutable: it cannot be overwritten or deleted.
+A bad version can be yanked from new dependency resolution, but existing
+lockfiles and downloads remain valid.
+
+## Prerequisites
+
+- The implementation is reviewed and merged to `main`.
+- Required control-plane and service deployments are complete.
+- The version follows SemVer; a public Rust API break requires a major release.
+- `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, and comparison links agree.
+- The packaged README links repository documentation to the exact release tag,
+  not `HEAD` or a moving branch.
+- crates.io credentials are stored in Cargo's credential provider or a scoped
+  `CARGO_REGISTRY_TOKEN`, never in the repository or command history.
+
+## 1. Validate the exact main commit
+
+```bash
+git switch main
+git pull --ff-only origin main
+git status --short
+git rev-parse HEAD
+```
+
+Run the complete [validation checklist](VALIDATION.md), including strict
+rustdoc, Worker/workerd, package, container, and authorized live-provider gates.
+Then inspect the package itself:
+
+```bash
+cargo package --locked --list
+cargo publish --locked --dry-run
+bash scripts/validate_docker_release.sh workflows
+bash scripts/validate_docker_release.sh context
+```
+
+The dry-run verifies the crate archive and crates.io metadata. It does not prove
+that a Cloudflare, Docker, Kubernetes, or control-plane deployment works. The
+Docker checks prove that PR, `main`, and manual events are build-only, that a
+mismatched release tag or a tag outside trusted `main` is rejected, and that the
+deny-by-default context admits only the release inputs copied by the Dockerfile.
+The workflow-wiring check also proves that credential-bearing provider smoke
+is job-gated to `refs/heads/main` before checkout or secret exposure, then
+checks out the exact scheduled/manual event SHA.
+
+## 2. Publish once
+
+Reconfirm that the tree is clean and still equals `origin/main` immediately
+before publication:
+
+```bash
+git fetch origin main
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+test -z "$(git status --porcelain)"
+cargo publish --locked
+```
+
+Do not retry blindly after a timeout. Check crates.io first: the upload may have
+succeeded even if the local client lost the response.
+
+## 3. Verify, tag, and create the GitHub release
+
+Only after crates.io shows the version. The commands below use 2.0.1 as the
+release example; preparing this runbook does not mean the version has already
+been published:
+
+```bash
+NOVEUM_RELEASE_VERSION=2.0.1
+git tag -a "v${NOVEUM_RELEASE_VERSION}" -m "v${NOVEUM_RELEASE_VERSION}"
+git push origin "v${NOVEUM_RELEASE_VERSION}"
+gh release create "v${NOVEUM_RELEASE_VERSION}" --verify-tag \
+  --title "v${NOVEUM_RELEASE_VERSION}" --generate-notes
+```
+
+The tag push is the **only** publishing trigger for release containers. The
+Docker workflow verifies that the ref is exactly
+`v${Cargo package version}` and that its commit is contained in trusted `main`
+before logging into either registry, then publishes `${NOVEUM_RELEASE_VERSION}`
+and `latest` to both
+`ghcr.io/noveum/ai-gateway` and `noveum/noveum-ai-gateway`. Pull requests,
+`main` pushes, and manual workflow runs never publish. Wait for that exact tag's
+workflow to finish, then verify both versioned images and record their digests;
+do not infer success from the moving `latest` tag.
+
+Verify all of the following resolve to the same version and source commit:
+
+- crates.io version and checksum;
+- docs.rs build;
+- Git tag;
+- GitHub release; and
+- GHCR and Docker Hub version tags, OCI version/source-revision labels, fixed
+  `65532:65532` runtime identity, and recorded digests;
+- production runtime `/health` response after service deployment.
+
+For v2.0.1, do not declare completion until the exact version is visible from
+the generic
+[crates.io package](https://crates.io/crates/noveum-ai-gateway),
+[docs.rs package](https://docs.rs/noveum-ai-gateway), and
+[GitHub releases page](https://github.com/Noveum/ai-gateway/releases).
+
+## Emergency response
+
+Roll back service deployments using their recorded immutable artifact. If the
+crate itself must not be selected by new builds:
+
+```bash
+NOVEUM_BAD_VERSION=2.0.1
+cargo yank --vers "$NOVEUM_BAD_VERSION" noveum-ai-gateway
+```
+
+Document why the version was yanked and publish a corrected new version. Never
+move or recreate an existing release tag, overwrite a versioned container tag,
+or attempt to replace an existing crate archive.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,12 +1,24 @@
-Things to do ->
+# Roadmap after v2.0
 
-Improve /health path. Add a readiness check (e.g. verify configured upstreams /
-registered exporters are healthy) returning a non-200 on failure. Useful for
-kubernetes deployments.
+This is a list of known product gaps, not a commitment or release schedule.
+Open an issue before implementation so the behavior and compatibility contract
+can be agreed first.
 
-Future: optional Noveum platform integration — export per-request traces to the
-Noveum trace API, and hosted Nova Guard policy distribution + budget reservation.
-Deferred for now; the gateway runs self-contained with local policies.
-
-The gateway reports these errors after is has been running idle for sometime. Is there a way to optimize this, in senses less errors.
-
+- Add a distinct readiness endpoint that can represent configured control-plane
+  dependencies without making liveness depend on third-party provider health.
+- Add configurable CORS and a documented gateway-auth integration contract.
+  v2.0.x remains permissive and relies on an external access-control layer.
+- Add persistent Worker-native telemetry (Workers Logs/Analytics Engine/Queues)
+  with prompt-data minimization and explicit retention controls.
+- Generate Rust and platform pricing tables from `pricing/catalog.json` instead
+  of maintaining hand-written mirrors.
+- Add Workers KV or another reviewed source for globally distributed stateless
+  policy bundles; Worker v2.0.x reads vars/secrets, not KV.
+- Add Bedrock tool/multimodal conversion and source-Region-aware strict pricing
+  before expanding strict admission beyond the documented Claude surface.
+- Design streaming output-phase policy enforcement without losing backpressure
+  or sending content before a terminal block decision.
+- Add OpenAPI generation and a hosted API reference. `/docs` and
+  `/openapi.json` intentionally remain 404 in v2.0.1.
+- Automate authorized edge/provider smoke tests separately from hermetic pull
+  request CI, with low budgets and reliable cleanup.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,0 +1,194 @@
+# Validation checklist
+
+Use this checklist for a release candidate, a configuration change, or a
+production deployment. Record the commit, artifact digest/version, runtime
+configuration mode, test time, and result. “CI passed” is not evidence that a
+specific production deployment is healthy.
+
+## 1. Exact source and dependency graph
+
+```bash
+git status --short
+git rev-parse HEAD
+cargo metadata --locked --format-version 1 >/dev/null
+cargo fmt --all -- --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features
+git diff --check
+```
+
+The tree must be clean for a release artifact. Confirm the resulting SHA is the
+reviewed SHA and contains no credentials or local environment files.
+
+## 2. Hermetic native and policy tests
+
+```bash
+cargo test --locked --lib
+cargo test --locked --bin noveum-ai-gateway runtime_uses_the_configured_worker_thread_count
+cargo test --locked --test novaguard_platform
+cargo test --locked --test policy_integration
+cargo test --locked --test run_integration_tests streaming_smoke_
+cargo test --locked --test run_integration_tests request_body_can_select_
+cargo test --locked --test run_integration_tests model_override_uses_
+```
+
+These checks require no paid provider credentials. The three provider-harness
+filters select seven network-free regressions: five streaming helpers, one
+request-body helper, and one model-override helper. Together they cover the
+policy engine, platform wire contract, routing helpers, and provider-aware
+terminal-usage behavior without making a live call.
+
+## 3. Cloudflare Worker and workerd
+
+Use the pinned toolchain documented in
+[Cloudflare Worker operations](CLOUDFLARE_WORKER.md):
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo check --locked --target wasm32-unknown-unknown --no-default-features --lib
+worker-build --release
+npx --yes wrangler@4.120.0 deploy --dry-run
+scripts/novaguard_worker_e2e.sh
+```
+
+The 13-phase workerd suite is the hermetic proof for Worker-only behavior such
+as `worker::Fetch`, `ctx.wait_until` settlement, streaming tees, refresh
+ordering, lease safety, bodyless `HEAD /` parity, cross-provider credential
+stripping, and the complete Worker Bedrock unsupported-feature error envelope.
+It does not replace a real edge smoke test.
+
+## 4. Package and container
+
+```bash
+cargo build --locked --release
+cargo package --locked --list
+cargo publish --locked --dry-run
+bash scripts/validate_docker_release.sh workflows
+bash scripts/validate_docker_release.sh context
+NOVEUM_VALIDATION_REVISION="$(git rev-parse HEAD)"
+docker build --pull \
+  --build-arg VERSION=2.0.1 \
+  --build-arg REVISION="$NOVEUM_VALIDATION_REVISION" \
+  --tag noveum-ai-gateway:candidate .
+bash scripts/validate_docker_release.sh runtime-image \
+  noveum-ai-gateway:candidate "$NOVEUM_VALIDATION_REVISION"
+```
+
+The runtime validator starts the image on a dynamic localhost port with a
+read-only root filesystem, all capabilities dropped, and
+`no-new-privileges`. It proves the configured and effective identity is exactly
+`65532:65532`, the OCI version and source revision match the candidate, and
+`/health` reports 2.0.1. The image sets `HOST=0.0.0.0` so Docker port publishing
+and orchestrator probes can reach it; a native binary outside a container still
+defaults to loopback. Inspect `cargo package --list` for accidental internal
+reports, secrets, logs, and generated artifacts. A Cargo dry-run does not
+validate Docker or Cloudflare.
+
+The release-mode self-test proves that PR, `main`, and manual workflow events
+are build-only, only the exact `v${Cargo package version}` tag publishes, and a
+mismatched or non-mainline `v*` tag fails. The same wiring check proves that
+credential-bearing provider smoke is job-gated to `refs/heads/main` before
+checkout or secret exposure and checks out the exact event SHA. The context
+check proves that the deny-by-default
+`.dockerignore` admits only `Cargo.toml`, `Cargo.lock`, `src/`, `schema/`, and
+`pricing/`, while representative `.env`, Wrangler-state, and unlisted files
+cannot be copied. Release tags publish the version and `latest` to GHCR and
+Docker Hub; production still pins the verified version digest.
+
+Confirm the immutable image identifies the release you built:
+
+```bash
+docker image inspect noveum-ai-gateway:candidate \
+  --format '{{ index .Config.Labels "org.opencontainers.image.version" }} {{ index .Config.Labels "org.opencontainers.image.revision" }} {{ .Config.User }}'
+```
+
+## 5. Live provider matrix
+
+Use a dedicated low-budget test account, low output limits, and non-sensitive
+prompts. Never print or commit keys. At minimum test:
+
+| Provider path | Buffered | Streaming | Additional check |
+|---|:---:|:---:|---|
+| OpenAI | required | required | terminal usage and `[DONE]` |
+| Anthropic | required | required | Messages conversion, terminal usage, optional function tool stream |
+| Groq | required | required | response headers and provider/model identity |
+| Together | when a test key is available | when a test key is available | current serverless model ID and terminal usage |
+| Fireworks | when a test key is available | when a test key is available | exact account-qualified model ID and terminal usage |
+| Gemini | when a test key is available | when a test key is available | OpenAI-compatible route and billed-output usage |
+| OpenRouter | when a test key is available | when a test key is available | resolved model identity and conservative pricing boundary |
+| Bedrock | when credentials/model entitlement are safely available | native only; the v2.0.1 Worker must return 400 `unsupported_feature` for `stream: true` | correct Region/model, SigV4, optional STS session token on both runtimes, and no credential logging |
+
+For any unavailable key, model, Region, or account entitlement, record “not
+tested” rather than treating absence as a pass. Provider credentials
+authenticate the upstream; a Noveum key cannot replace them.
+
+The checked-in smoke harness requests terminal usage explicitly only where that
+field is part of the reviewed contract (OpenAI and Groq). Together and
+Fireworks must emit terminal usage in their final provider chunks without an
+undocumented `stream_options` option. A stream without authoritative usage is a
+failed smoke, not a pass with incomplete accounting.
+
+### Dated post-release evidence
+
+On 2026-08-24, `https://gate.noveum.ai` passed buffered and streaming probes with
+OpenAI `gpt-4o-mini`, Anthropic `claude-haiku-4-5-20251001`, Groq
+`openai/gpt-oss-20b`, Together
+`meta-llama/Llama-3.3-70B-Instruct-Turbo`, Fireworks
+`accounts/fireworks/models/deepseek-v4-flash-0731`, Gemini
+`gemini-2.5-flash-lite`, and OpenRouter `openrouter/free`. Direct AWS access to
+`amazon.nova-micro-v1:0` passed buffered and streaming calls, but AWS credential
+security prevented forwarding those credentials through the gateway; gateway
+Bedrock remained unverified in that live audit. Azure OpenAI is not a routable
+provider in v2.0.1. These results belong to that date, route, credential set,
+and deployment—not to future provider availability.
+
+## 6. Platform-managed Nova Guard
+
+Use temporary shadow/strict policies and delete them after the test:
+
+- [ ] Key scopes are exactly `guardrails:read`, `guardrails:ingest`, plus
+  `projects:read` for a native shared caller.
+- [ ] `/policies/effective` resolves and the expected policy source is
+  `project` or `org`.
+- [ ] Project policies read project counters; organization policies read the
+  nested organization counters and never substitute project state.
+- [ ] A bounded strict call is admitted once and completes once with actual
+  input/output usage.
+- [ ] An unbounded strict call returns 400 `missing_output_limit` before the
+  provider is called.
+- [ ] A gateway-side block cancels its reservation; an uncertain provider or
+  stream outcome abandons rather than releasing the hold.
+- [ ] Two projects in one organization see separate project counters and the
+  same aggregate organization counter.
+- [ ] No active test reservation or temporary policy remains after cleanup.
+
+## 7. Production deployment
+
+Before promotion:
+
+- [ ] Record the current deployment/image/version as the rollback target.
+- [ ] Confirm the candidate's bindings and secrets by **name**, without printing
+  values.
+- [ ] Confirm the tenancy choice. Never bind one dedicated project to a shared
+  public hostname.
+- [ ] Confirm persistent logging or a real-time tail is available.
+
+After promotion:
+
+- [ ] `GET /` returns the expected version/runtime page, and `HEAD /` returns
+  the same status and security/cache headers with no body.
+- [ ] Both the canonical domain and runtime-native domain return `/health` with
+  the intended version.
+- [ ] One low-cost buffered and one streaming call succeed through the exact
+  production route.
+- [ ] Authentication failures return the expected 401/403 and never reach the
+  provider.
+- [ ] Error rate, latency, and Worker/runtime exceptions remain normal through
+  the observation window.
+- [ ] Guarded deployments show expected admission and settlement; transparent
+  deployments have no accidental Noveum bridge bindings.
+- [ ] Rollback command/manifest is still valid.
+
+If any mandatory check fails, stop promotion and restore the recorded artifact.
+Do not “fix” a guarded outage by silently removing enforcement; use a deliberate,
+audited emergency decision.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -33,7 +33,7 @@ cargo test --locked --test run_integration_tests model_override_uses_
 ```
 
 These checks require no paid provider credentials. The three provider-harness
-filters select seven network-free regressions: five streaming helpers, one
+filters select eight network-free regressions: six streaming helpers, one
 request-body helper, and one model-override helper. Together they cover the
 policy engine, platform wire contract, routing helpers, and provider-aware
 terminal-usage behavior without making a live call.
@@ -130,8 +130,10 @@ failed smoke, not a pass with incomplete accounting.
 
 ### Dated post-release evidence
 
-On 2026-08-24, `https://gate.noveum.ai` passed buffered and streaming probes with
-OpenAI `gpt-4o-mini`, Anthropic `claude-haiku-4-5-20251001`, Groq
+On 2026-08-24, the transparent production Cloudflare Worker deployment v57
+(`456f0723-dfc7-4236-bdf0-cfa83daad3c3`) at `https://gate.noveum.ai` was running
+gateway v2.0.0 and passed buffered and streaming probes with OpenAI
+`gpt-4o-mini`, Anthropic `claude-haiku-4-5-20251001`, Groq
 `openai/gpt-oss-20b`, Together
 `meta-llama/Llama-3.3-70B-Instruct-Turbo`, Fireworks
 `accounts/fireworks/models/deepseek-v4-flash-0731`, Gemini
@@ -139,8 +141,10 @@ OpenAI `gpt-4o-mini`, Anthropic `claude-haiku-4-5-20251001`, Groq
 `amazon.nova-micro-v1:0` passed buffered and streaming calls, but AWS credential
 security prevented forwarding those credentials through the gateway; gateway
 Bedrock remained unverified in that live audit. Azure OpenAI is not a routable
-provider in v2.0.1. These results belong to that date, route, credential set,
-and deployment—not to future provider availability.
+provider in v2.0.1. The AWS result was a direct-provider check, not a Worker or
+v2.0.1 gateway check. None of this dated v2.0.0 evidence substitutes for the
+v2.0.1 deployment checklist below. These results belong to that date, route,
+credential set, and deployment—not to future provider availability.
 
 ## 6. Platform-managed Nova Guard
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,32 +1,136 @@
-# Configuration
+# Configuration and credentials
 
-Noveum AI Gateway is configured entirely through environment variables, read once
-at startup. The full, authoritative list lives in the
-[README "Configuration" section](../README.md#configuration-environment-variables);
-this page summarizes the groups.
+The native gateway reads environment variables at startup. The Cloudflare
+Worker reads equivalent Wrangler vars/secrets per isolate; filesystem policy
+paths and native-only settings do not apply there.
 
-## Server / runtime
-- `PORT` (default `3000`) — listen port
-- `HOST` (default `127.0.0.1`) — bind address
-- `WORKER_THREADS` (default: derived from CPU cores) — Tokio worker threads
-- `MAX_CONNECTIONS` (default `10000`) — max idle HTTP connections per upstream host
-- `RUST_LOG` (default `info`) — tracing filter
+## Choose one mode
 
-## Telemetry (optional)
-- `DEBUG_METRICS` (default `false`) — console metrics exporter
-- `DEPLOYMENT_ENVIRONMENT` (default `development`) — resource tag
+| Mode | Required settings | Forbidden settings | Runtime |
+|---|---|---|---|
+| Transparent | none | none | native or Worker |
+| Local policies | `NOVEUM_GUARD_POLICIES_FILE` or `NOVEUM_GUARD_POLICIES` | `NOVEUM_GUARD_TENANCY=shared`; do not also configure the dedicated platform pair | file: native only; inline: native or Worker |
+| Platform dedicated | `NOVEUM_API_KEY`, `NOVEUM_GUARD_PROJECT_ID`; optionally `NOVEUM_GUARD_TENANCY=dedicated` | `NOVEUM_GUARD_TENANCY=shared` | native or Worker |
+| Platform shared | `NOVEUM_GUARD_TENANCY=shared`; caller sends `x-noveum-api-key` | process-wide `NOVEUM_API_KEY`, `NOVEUM_GUARD_PROJECT_ID`, and local bundle | native only |
 
-  Add new exporters by implementing `MetricsExporter`; see
-  [telemetry-plugins.md](telemetry-plugins.md).
+An unset tenancy with a complete Noveum key/project pair means dedicated mode
+for backward compatibility. Shared mode is never inferred. An incomplete pair,
+blank value, unknown tenancy, or incompatible combination is an error rather
+than a silent pass-through. The native gateway validates this at startup. The
+Worker evaluates runtime bindings per proxy request, so `/` and `/health` can
+remain available while `/v1/*` returns a configuration error.
 
-## Nova Guard (optional)
-- `NOVEUM_GUARD_ENABLED`, `NOVEUM_GUARD_POLICIES_FILE`, `NOVEUM_GUARD_POLICIES`,
-  `NOVEUM_GUARD_BLOCK_RESPONSE_MODE`. See [NOVA_GUARD.md](NOVA_GUARD.md).
+Local and platform policy sources are alternatives, not additive layers. When a
+complete dedicated bridge is present, the Noveum control plane is the policy
+source; an inline/local bundle is not combined with it. Remove local-source
+settings from a dedicated deployment so the intended source is unambiguous.
+
+The production Cloudflare hostname `gate.noveum.ai` is transparent because it
+is shared by callers. Binding it to one dedicated project would attribute every
+call to that project. Use one dedicated Worker/domain per project, or the native
+shared mode, when platform-managed enforcement is required.
+
+## Server and telemetry (native)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `HOST` | `127.0.0.1` | Bind address. Use `0.0.0.0` in a container. |
+| `PORT` | `3000` | Listen port. Must be a valid `u16`. |
+| `WORKER_THREADS` | derived from CPU count | Positive Tokio runtime worker-thread count. Zero prevents startup. |
+| `MAX_CONNECTIONS` | `10000` | Maximum idle HTTP connections retained per upstream host. |
+| `RUST_LOG` | `info` | Tracing filter, for example `noveum_ai_gateway=debug`. |
+| `DEBUG_METRICS` | `false` | Registers the console metrics exporter. Output can include prompt and response bodies. |
+| `DEPLOYMENT_ENVIRONMENT` | `development` | `deployment.environment` field in exported telemetry. |
+
+Version 2.0.1 honors both `HOST` and `WORKER_THREADS`: it builds the Tokio
+runtime with the configured worker count before startup. Version 2.0.0 read
+these settings but had startup bugs that left the listener on the wildcard
+address and the Tokio runtime at its previously created worker count. Apply an
+external network boundary while upgrading a v2.0.0 deployment.
+
+Configuration is read once. Restart or redeploy after changing it.
+
+## Nova Guard policy source
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `NOVEUM_GUARD_ENABLED` | `true` | Master switch. `false`, `0`, `no`, `off`, `disabled`, or an empty value disables the engine. |
+| `NOVEUM_GUARD_POLICIES_FILE` | unset | Native-only path to a JSON policy bundle. |
+| `NOVEUM_GUARD_POLICIES` | unset | Inline JSON policy bundle; on Workers, store sensitive bundles as a secret. |
+| `NOVEUM_GUARD_BLOCK_RESPONSE_MODE` | `synthetic_success` | `synthetic_success` returns a refusal-shaped HTTP 200; `provider_error` returns an HTTP 403 error envelope. |
+| `NOVEUM_GUARD_ASSUMED_OUTPUT_TOKENS` | `1024` | Fallback estimate for advisory cost caps and rate-only accounting; never satisfies an applicable strict cost cap's explicit-bound requirement. |
+
+A configured but unreadable, malformed, future-major, or unenforceable local
+bundle prevents native startup. The Worker evaluates its inline binding per
+proxy request, so its information and health routes can remain available while
+`/v1/*` returns a configuration error. With no policy source and no platform
+bridge, the gateway is a transparent proxy.
+
+## Platform bridge
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `NOVEUM_API_KEY` | unset | Dedicated deployment service key. Store as a secret. Must be absent in shared mode. |
+| `NOVEUM_GUARD_PROJECT_ID` | unset | Fixed dedicated project. Must be absent in shared mode. |
+| `NOVEUM_API_URL` | `https://api.noveum.ai` | Noveum control-plane base URL. |
+| `NOVEUM_GUARD_TENANCY` | inferred dedicated or transparent | Explicit `dedicated` or `shared`. Worker refuses `shared`. |
+| `NOVEUM_GUARD_COST_ENFORCEMENT` | policy value | Native-only `strict` or `advisory` deployment override. `strict` requires the platform bridge. Worker always uses each policy's `enforcementMode`. |
+| `NOVEUM_GUARD_ALLOW_UNGUARDED_START` | `false` | Emergency-only escape hatch when the first policy fetch fails. Traffic is unguarded until a later fetch succeeds. |
+| `NOVEUM_GUARD_TENANT_TTL_SECS` | `300` | Shared native mode: credential-to-tenant resolution TTL. |
+| `NOVEUM_GUARD_TENANT_CACHE_MAX` | `1024` | Shared native mode: maximum warm tenant runtimes. |
+| `NOVEUM_GUARD_USAGE_FLUSH_MS` | `2000` | Native usage batching interval. Primarily a test/diagnostic knob; avoid unnecessary production tuning. |
+| `NOVEUM_GUARD_WORKER_UPSTREAM_TIMEOUT_MS` | `600000` | Worker-only admitted provider deadline. May be lowered but cannot exceed 10 minutes. |
+
+### Required key scopes
+
+| Scope | Dedicated service key | Shared caller key |
+|---|:---:|:---:|
+| `guardrails:read` | required | required |
+| `guardrails:ingest` | required | required |
+| `projects:read` | not required | required |
+
+The dedicated service key is process-wide. The shared caller key arrives in
+`x-noveum-api-key`, is used only for that derived tenant, and is removed before
+provider dispatch.
+
+## Provider base URL overrides
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `OPENAI_BASE_URL` | `https://api.openai.com` | Override only the literal `x-provider: openai` upstream. |
+| `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | Override the Anthropic origin; the adapter still appends `/v1/messages`. |
+
+Leave these unset in production unless the target is an intentional compatible
+proxy. An empty or whitespace-only override is treated as unset and uses the
+default URL. Other provider routes use their compiled upstream URL in the 2.0
+line.
 
 ## Per-request headers
-Provider selection and attribution are per request, via headers:
-- `x-provider` — required; selects the upstream (e.g. `openai`, `anthropic`, `groq`, …)
-- `Authorization: Bearer <key>` — the upstream provider's API key (Bedrock uses
-  `x-aws-access-key-id` / `x-aws-secret-access-key` / `x-aws-region`)
-- `x-project-id`, `x-organization-id`, `x-user-id`, `x-experiment-id` — attribution
-  tags captured into the per-request metrics
+
+| Header | Meaning |
+|---|---|
+| `x-provider` | Optional provider selector, such as `openai`, `anthropic`, `groq`, `fireworks`, `together`, or `bedrock`; absence defaults to OpenAI. |
+| `Authorization: Bearer …` | Provider credential for OpenAI-style routes; Anthropic also accepts `x-api-key`. |
+| `x-aws-access-key-id`, `x-aws-secret-access-key`, `x-aws-region` | Bedrock credential and source Region. |
+| `x-aws-session-token` | Optional temporary Bedrock credential token on native and Worker runtimes. |
+| `x-noveum-api-key` | Native shared-tenancy caller credential; never a provider credential. |
+| `x-project-id` | Attribution, or an entitled-project selector in shared mode. Not authentication. |
+| `x-organization-id` / `x-organisation-id` | Attribution, or a shared-mode confirmation that must match the derived organization. |
+| `x-user-id`, `x-experiment-id` | Optional telemetry attribution. |
+
+Provider keys and AWS credential headers must travel only over TLS to a gateway
+you control. Configure access logs and reverse proxies to redact them.
+
+## Secret storage
+
+- Native process/container: inject secrets from the platform secret manager;
+  keep `.env` files out of images and source control.
+- Kubernetes: reference a Secret or an external secret provider rather than
+  placing values in a Deployment manifest.
+- Cloudflare: source values from an approved secret manager and stage production
+  changes with `wrangler versions secret` plus the versioned promotion flow.
+  The ordinary `wrangler secret put` deploys immediately. Never commit a secret
+  to `[vars]`, pass its value as a command argument, or print it in CI.
+
+See [Nova Guard](NOVA_GUARD.md) for policy semantics and
+[Cloudflare Worker operations](CLOUDFLARE_WORKER.md) for Worker-specific setup.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,36 +1,123 @@
-# Deployment Guide
+# Native, Docker, and Kubernetes deployment
 
-## Deployment Options
+This guide covers the native Axum server. For the edge runtime, use the
+[Cloudflare Worker runbook](CLOUDFLARE_WORKER.md).
 
-### Docker Deployment
+## Production contract
 
-#### Using Docker Compose
-```yaml
-version: '3.8'
-services:
-  noveum:
-    image: noveum/noveum-ai-gateway:latest
-    ports:
-      - "3000:3000"
-    environment:
-      - RUST_LOG=info
-      - PORT=3000
-```
+- The native process serves `GET /`, `HEAD /`, `GET /health`, and `/v1/*`.
+- Beginning with v2.0.1, `GET /` is a static, no-JavaScript information page
+  with a restrictive CSP and five-minute cache; it is not an administrative
+  console. `HEAD /` returns the same status and headers with an empty body.
+- `GET /health` is the only health route in v2.0.1. It reports process health
+  and version, not provider credentials or control-plane reachability. There is
+  no `/ready` endpoint.
+- Provider credentials arrive per request. A dedicated Noveum service key is a
+  deployment secret; a native shared caller key arrives per request.
+- Transparent and dedicated modes do not authenticate general callers. Put the
+  service behind TLS and an access-control layer when it must be private.
 
-#### Manual Docker Commands
+Read [Configuration](configuration.md) and choose the tenancy mode before
+creating a manifest.
+
+## Run the binary
+
 ```bash
-# Build the image
-docker build -t noveum-ai-gateway .
-
-# Run the container
-docker run -d \
-  -p 3000:3000 \
-  -e RUST_LOG=info \
-  --name noveum \
-  noveum-ai-gateway
+cargo install noveum-ai-gateway --version 2.0.1 --locked
+HOST=0.0.0.0 PORT=3000 RUST_LOG=info noveum-ai-gateway
 ```
 
-### Kubernetes Deployment
+Version 2.0.1 honors `HOST` and defaults to loopback. Container and pod
+deployments must set `HOST=0.0.0.0` so their port or probe can reach the
+process. Version 2.0.0 had a binding bug and always listened on the wildcard
+address, so retain an external network boundary during an upgrade.
+
+For a system service, run as an unprivileged user, inject environment variables
+from the host secret manager, set restart limits, and place a TLS/authenticated
+reverse proxy in front. Do not place provider keys in the service environment;
+callers supply them per request.
+
+## Docker
+
+Release automation builds linux/amd64 on pull requests, `main`, and manual
+runs, but those events publish nothing. It publishes the Cargo version and
+`latest` to both `ghcr.io/noveum/ai-gateway` and
+`noveum/noveum-ai-gateway` only when a pushed Git tag exactly matches
+`v${Cargo package version}` **and** that tag's commit is already contained in
+trusted `main`. A mismatched or unreviewed `v*` tag fails before registry login.
+For this release, only `v2.0.1` on the reviewed mainline can publish the `2.0.1`
+images. A release-preparation commit or crate publication therefore does not
+prove that the container exists: confirm the versioned tag and digest in the
+intended registry before rollout, then pin that digest for production. `latest`
+moves only on a matching release tag, but remains mutable and is not a release
+identifier.
+
+The repository's `.dockerignore` denies the entire working tree, then admits
+only `Cargo.toml`, `Cargo.lock`, `src/`, `schema/`, and `pricing/`. Docker still
+receives the selected Dockerfile separately. This keeps `.env` files, Wrangler
+state, generated bundles, logs, tests, documentation, and unrelated local files
+out of local and remote BuildKit contexts. The release validation script proves
+both the required allowlist and representative forbidden paths before CI builds
+an image.
+
+```bash
+docker pull --platform linux/amd64 noveum/noveum-ai-gateway:2.0.1
+docker run --detach \
+  --name noveum-ai-gateway \
+  --publish 127.0.0.1:3000:3000 \
+  --env HOST=0.0.0.0 \
+  --env PORT=3000 \
+  --env RUST_LOG=info \
+  --read-only \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  noveum/noveum-ai-gateway:2.0.1
+```
+
+Bind the published port to a private interface or localhost and proxy it through
+TLS. Verify the exact running version:
+
+```bash
+curl --fail --silent http://127.0.0.1:3000/health
+docker logs --since 5m noveum-ai-gateway
+```
+
+The release image declares the fixed unprivileged identity `65532:65532`. CI
+starts that exact identity with a read-only root filesystem, all capabilities
+dropped, and `no-new-privileges`, then requires `/health` to report the Cargo
+version. Read-only policy or configuration mounts must be readable by UID/GID
+65532, and every parent directory must be traversable by that identity. Set
+ownership and permissions deliberately before rollout; do not solve a mount
+error by adding `--user 0`. Any `--user` override departs from the tested
+default and needs an explicit security review.
+
+### Local policy bundle
+
+Mount a read-only file instead of baking it into the image:
+
+```bash
+docker run --detach \
+  --name noveum-ai-gateway \
+  --publish 127.0.0.1:3000:3000 \
+  --env HOST=0.0.0.0 \
+  --env NOVEUM_GUARD_POLICIES_FILE=/etc/noveum/nova-guard.json \
+  --mount type=bind,src="$(pwd)/nova-guard.json",dst=/etc/noveum/nova-guard.json,readonly \
+  --read-only \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  noveum/noveum-ai-gateway:2.0.1
+```
+
+For a dedicated platform bridge, inject `NOVEUM_API_KEY` from a secret manager
+and set `NOVEUM_GUARD_PROJECT_ID`; do not use a command-line `--env
+NOVEUM_API_KEY=value`, which can expose the value in shell history and process
+metadata.
+
+## Kubernetes
+
+The example below is transparent. Add an authenticated Ingress/Gateway and
+NetworkPolicy for production exposure. Replace the image tag with the verified
+digest used by your release system.
 
 ```yaml
 apiVersion: apps/v1
@@ -39,6 +126,12 @@ metadata:
   name: noveum-ai-gateway
 spec:
   replicas: 3
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: noveum-ai-gateway
@@ -49,108 +142,154 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-      - name: noveum-ai-gateway
-        image: noveum/noveum-ai-gateway:latest
-        ports:
-        - containerPort: 3000
-        env:
-        - name: RUST_LOG
-          value: "info"
-        resources:
-          limits:
-            cpu: "1"
-            memory: "1Gi"
-          requests:
-            cpu: "500m"
-            memory: "512Mi"
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 3000
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 3000
-          initialDelaySeconds: 5
-          periodSeconds: 10
+        - name: gateway
+          image: noveum/noveum-ai-gateway:2.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: HOST
+              value: "0.0.0.0"
+            - name: PORT
+              value: "3000"
+            - name: RUST_LOG
+              value: "info"
+            - name: DEPLOYMENT_ENVIRONMENT
+              value: "production"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: noveum-ai-gateway
+spec:
+  selector:
+    app: noveum-ai-gateway
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  type: ClusterIP
 ```
 
-+```yaml
-+apiVersion: v1
-+kind: Service
-+metadata:
-+  name: noveum-ai-gateway
-+spec:
-+  selector:
-+    app: noveum-ai-gateway
-+  ports:
-+    - protocol: TCP
-+      port: 80
-+      targetPort: 3000
-+  type: ClusterIP
-+```
+Because `/health` is process-only, a pod can be ready while a particular
+provider key is invalid or the upstream is degraded. Monitor real, low-cost
+synthetic calls separately. A guarded deployment should also monitor policy
+fetch, admission, and settlement outcomes.
 
-## Production Considerations
+### Dedicated bridge secret example
 
-### Security Checklist
-- [ ] Enable TLS/SSL
-- [ ] Configure proper CORS settings
-- [ ] Set up API key authentication
-- [ ] Enable rate limiting
-- [ ] Configure proper logging
-- [ ] Set up monitoring and alerts
-- [ ] Configure AWS IAM roles with least privilege
-- [ ] Enable AWS CloudTrail for API activity logging
-- [ ] Set up AWS VPC endpoints for Bedrock
-- [ ] Configure AWS KMS for encryption
-- [ ] Implement AWS WAF rules
+Create the Secret through the cluster's approved secret provider. Reference it
+without putting the value in this manifest:
 
-
-## Scaling Strategies
-
-### Horizontal Scaling
-```bash
-# Kubernetes scaling
-kubectl scale deployment noveum-ai-gateway --replicas=5
-
-# Docker Swarm scaling
-docker service scale noveum_gateway=5
-```
-
-### Resource Allocation
 ```yaml
-resources:
-  limits:
-    cpu: "2"
-    memory: "2Gi"
-  requests:
-    cpu: "1"
-    memory: "1Gi"
+env:
+  - name: NOVEUM_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: noveum-gateway
+        key: api-key
+  - name: NOVEUM_GUARD_PROJECT_ID
+    value: "project-id"
+  - name: NOVEUM_GUARD_TENANCY
+    value: "dedicated"
 ```
 
-## Maintenance
+The service key needs `guardrails:read` and `guardrails:ingest`. Shared mode has
+no process-wide key; callers need those scopes plus `projects:read`.
 
-### Update Procedure
+## Rollout
+
+1. Run the [validation checklist](VALIDATION.md) on the exact image source.
+2. Record the current image and ReplicaSet revision.
+3. Apply the candidate and wait for rollout completion.
+4. Confirm the in-cluster and external `/health` versions.
+5. Run low-cost buffered and streaming provider probes through the production
+   route.
+6. Observe HTTP errors, provider errors, latency, restarts, and Nova Guard
+   settlement before increasing traffic.
+
 ```bash
-# Rolling update in Kubernetes
-kubectl set image deployment/noveum-ai-gateway \
-  noveum-ai-gateway=noveum/noveum-ai-gateway:new-version
-
-# Docker update
-docker-compose pull
-docker-compose up -d
+kubectl get deployment noveum-ai-gateway \
+  -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+kubectl rollout history deployment/noveum-ai-gateway
+kubectl rollout status deployment/noveum-ai-gateway --timeout=5m
+kubectl get pods -l app=noveum-ai-gateway
+kubectl logs deployment/noveum-ai-gateway --since=10m
 ```
 
-### Health Checks
-```yaml
-livenessProbe:
-  httpGet:
-    path: /health
-    port: 3000
-  initialDelaySeconds: 3
-  periodSeconds: 3
-``` 
+## Rollback
+
+If validation fails, stop the rollout and restore the recorded artifact:
+
+```bash
+kubectl rollout undo deployment/noveum-ai-gateway
+kubectl rollout status deployment/noveum-ai-gateway --timeout=5m
+```
+
+Then repeat the external health and provider probes. Verify no temporary policy,
+active reservation, or half-applied secret remains. For Docker, start the
+previous version under a new container name, verify it on a private port, switch
+the reverse proxy, and only then remove the failed container.
+
+## Observability and alerts
+
+- Set `RUST_LOG=info` for normal operations; use targeted debug filters briefly.
+- Keep `DEBUG_METRICS=false` unless prompt/response content is safe to print.
+- Collect process exits/restarts, HTTP status, provider status, latency, TTFB,
+  token/cost completeness, Nova Guard blocks, admission failures, abandoned
+  reservations, and usage-queue warnings.
+- Alert on sustained 5xx, control-plane fail-closed blocks, settlement retry
+  exhaustion, and any mismatch between intended and reported `/health` version.
+
+See [Telemetry and log handling](logs.md) for the exported record and its data
+handling implications.
+
+## Production security checklist
+
+- [ ] TLS and caller authentication terminate before the gateway.
+- [ ] Sensitive headers are redacted from load-balancer, ingress, and APM logs.
+- [ ] CORS exposure is appropriate for the authenticated frontend.
+- [ ] Runtime runs unprivileged with a read-only filesystem and least privilege.
+- [ ] Secrets come from a secret manager and are absent from images/manifests.
+- [ ] Provider quotas, AWS IAM, and billing alerts are enabled independently of
+  Nova Guard.
+- [ ] Network egress is limited to intended provider and control-plane origins
+  where the platform permits it.
+- [ ] Rollback artifact and command have been tested.

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,272 +1,133 @@
-Example Request
-[
-  {
-    // The timestamp when this log was created (ISO 8601 or Unix time).
-    "timestamp": "2025-03-05T16:03:20.123Z",
+# Telemetry and log handling
 
-    // Identifies your service; helps group logs in observability tools.
-    "resource": {
-      "service.name": "noveum_ai_gateway",
-      "service.version": "1.0.0",
-      "deployment.environment": "production"
-    },
+The native gateway builds one `RequestMetrics` record for each proxied request.
+It includes provider/model identity, timing, sizes, status codes, token usage,
+estimated cost, attribution fields, and request/response bodies. Registered
+`MetricsExporter` plugins receive independent copies asynchronously.
 
-    // A short name or type for the log record.
-    "name": "ai_gateway_request_log",
+The built-in console exporter is disabled by default. Enable it only for a
+controlled diagnostic session:
 
-    // Additional attributes capturing the details of this request/response cycle.
-    "attributes": {
-      // Basic identifying fields for the request.
-      "id": "msg_29",
-      "threadId": "thread_29",
-      "org_id": "org_123",                    // Example org identifier
-      "user_id": "user_456",                  // Example user identifier
-      "project_id": "proj_design",            // Aligns with metadata.projectId
+```bash
+DEBUG_METRICS=true DEPLOYMENT_ENVIRONMENT=development RUST_LOG=info \
+  noveum-ai-gateway
+```
 
-      // Provider/model details
-      "provider": "azure",
-      "model": "gpt-4-turbo",
+It prints both the Rust debug representation and an OpenTelemetry-compatible
+JSON log. See [Telemetry exporters](telemetry-plugins.md) to implement a durable
+sink.
 
-      // Full request object (as-is from your logs).
-      "request": {
-        "model": "gpt-4-turbo",
-        "messages": [
-          {
-            "role": "user",
-            "content": "I'm designing a mobile app for personal finance management. Can you help me create user personas..."
-          }
-        ],
-        "temperature": 0.7
-      },
+## Record shape
 
-      // Full response object (as-is from your logs).
-      "response": {
-        "id": "chatcmpl-az-gpt4-001",
-        "choices": [
-          {
-            "message": {
-              "role": "assistant",
-              "content": "# User Personas for Personal Finance Management App\n\n## Persona 1: Career-Focused Millennial..."
-            },
-            "finish_reason": "stop"
-          }
-        ],
-        "usage": {
-          "prompt_tokens": 48,
-          "completion_tokens": 865,
-          "total_tokens": 913
-        }
-      },
+Fields are omitted or `null` when a provider does not report them. This is a
+representative, abbreviated record; version and values come from the running
+request:
 
-      // Metadata stored from your logs (latency, cost, tokens, statuses, etc.)
-      "metadata": {
-        "projectId": "proj_design",
-        "projectName": "UX Design",
-        "latency": 6250,
-        "tokens": { "input": 48, "output": 865, "total": 913 },
-        "cost": 0.0456,
-        "status": "success",
-        "provider_request_id": "chatcmpl-az-gpt4-001"
-      }
-    }
+```json
+{
+  "timestamp": "2026-08-24T12:00:00Z",
+  "resource": {
+    "service.name": "noveum_ai_gateway",
+    "service.version": "2.0.1",
+    "deployment.environment": "production"
   },
-  {
-    "timestamp": "2025-03-05T16:18:20.456Z",
-    "resource": {
-      "service.name": "noveum_ai_gateway",
-      "service.version": "1.0.0",
-      "deployment.environment": "production"
+  "name": "ai_gateway_request_log",
+  "attributes": {
+    "id": "msg_1234abcd",
+    "thread_id": "thread_1234abcd",
+    "org_id": "org_example",
+    "project_id": "project_example",
+    "user_id": "user_example",
+    "experiment_id": "experiment_example",
+    "provider": "openai",
+    "model": "gpt-4o-mini",
+    "request": {
+      "model": "gpt-4o-mini",
+      "messages": [{"role": "user", "content": "Example prompt"}],
+      "max_tokens": 32
     },
-    "name": "ai_gateway_request_log",
-
-    "attributes": {
-      "id": "msg_30",
-      "threadId": "thread_30",
-      "org_id": "org_789",                    // Example org identifier
-      "user_id": "user_999",                  // Example user identifier
-      "project_id": "proj_education",
-
-      "provider": "together",
-      "model": "llama-3-70b-instruct",
-
-      "request": {
-        "model": "llama-3-70b-instruct",
-        "messages": [
-          {
-            "role": "user",
-            "content": "I need to explain quantum computing to high school students. Can you provide a simple explanation..."
-          }
-        ],
-        "temperature": 0.5
-      },
-
-      "response": {
-        "id": "chatcmpl-tog-llama-001",
-        "choices": [
-          {
-            "message": {
-              "role": "assistant",
-              "content": "# Quantum Computing for High School Students\n\n## Simple Explanation\n\nQuantum computing..."
-            },
-            "finish_reason": "stop"
-          }
-        ],
-        "usage": {
-          "prompt_tokens": 36,
-          "completion_tokens": 595,
-          "total_tokens": 631
-        }
-      },
-
-      "metadata": {
-        "projectId": "proj_education",
-        "projectName": "Educational Content",
-        "latency": 5320,
-        "tokens": { "input": 36, "output": 595, "total": 631 },
-        "cost": 0.0315,
-        "status": "success",
-        "provider_request_id": "chatcmpl-tog-llama-001"
-      }
-    }
-  },
-  {
-    "timestamp": "2025-03-05T16:25:30.789Z",
-    "resource": {
-      "service.name": "noveum_ai_gateway",
-      "service.version": "1.0.0",
-      "deployment.environment": "production"
+    "response": {
+      "choices": [{"message": {"role": "assistant", "content": "Example response"}}]
     },
-    "name": "ai_gateway_request_log",
-
-    "attributes": {
-      "id": "msg_31",
-      "threadId": "thread_31",
-      "org_id": "org_123",
-      "user_id": "user_456",
-      "project_id": "proj_chat",
-
-      "provider": "groq",
-      "model": "llama-3.1-8b-instant",
-
-      "request": {
-        "model": "llama-3.1-8b-instant",
-        "messages": [
-          {
-            "role": "user",
-            "content": "Write a poem"
-          }
-        ],
-        "stream": true,
-        "max_tokens": 500
-      },
-
-      // For streaming responses, the response includes both the final response and all streamed chunks
-      "response": {
-        "id": "chatcmpl-ec855684-8495-420d-8807-9259228ac717",
-        "model": "llama-3.1-8b-instant",
-        "choices": [
-          {
-            "delta": {
-              "role": "assistant",
-              "content": "\"Moonlit Dreams\"\n\nThe night is dark, the stars are bright,\nA silver glow, a gentle light.\nThe moon, a crescent in the sky,\nLures me to dream, to wonder why.\n\nThe world is hushed, a peaceful sight,\nAs shadows dance, in the moon's pale light.\nThe trees, like sentinels of old,\nStand guard, their branches, stories untold.\n\nIn this quiet hour, I find my peace,\nA sense of calm, my worries release.\nThe moon's soft beams, upon my face,\nIlluminate my soul, a gentle, loving space.\n\nMy heart beats slow, my spirit free,\nAs I let go, and let the moment be.\nThe world, in all its beauty, shines,\nA reflection of the love that's mine.\n\nIn this moonlit night, I find my way,\nA path of dreams, that lead me to a brighter day.\nSo let the moon, its gentle light,\nGuide me through, the darkness of night.\n\nAnd when the dawn, breaks through the sky,\nAnd the sun's warm rays, upon my face, do lie,\nI'll hold on tight, to the memories of this night,\nAnd let the moon's soft beams, shine with all their might."
-            }
-          }
-        ],
-        "x_groq": {
-          "id": "req_01jnkrrz2ken1bej7emqf9j2af",
-          "usage": {
-            "queue_time": 0.291194089,
-            "prompt_tokens": 38,
-            "prompt_time": 0.002701306,
-            "completion_tokens": 256,
-            "completion_time": 0.341333333,
-            "total_tokens": 294,
-            "total_time": 0.344034639
-          }
-        },
-        // The streamed_data field contains all individual chunks received during streaming
-        "streamed_data": [
-          {
-            "nonce": "0955",
-            "id": "chatcmpl-ec855684-8495-420d-8807-9259228ac717",
-            "object": "chat.completion.chunk",
-            "created": 1741199015,
-            "model": "llama-3.1-8b-instant",
-            "system_fingerprint": "fp_fd87957473",
-            "choices": [
-              {
-                "index": 0,
-                "delta": {
-                  "role": "assistant",
-                  "content": ""
-                },
-                "logprobs": null,
-                "finish_reason": null
-              }
-            ],
-            "x_groq": {
-              "id": "req_01jnkrrz2ken1bej7emqf9j2af"
-            }
-          },
-          {
-            "nonce": "ef5fe2",
-            "id": "chatcmpl-ec855684-8495-420d-8807-9259228ac717",
-            "object": "chat.completion.chunk",
-            "created": 1741199015,
-            "model": "llama-3.1-8b-instant",
-            "system_fingerprint": "fp_fd87957473",
-            "choices": [
-              {
-                "index": 0,
-                "delta": {
-                  "content": "\"M"
-                },
-                "logprobs": null,
-                "finish_reason": null
-              }
-            ]
-          },
-          // Additional chunks omitted for brevity
-          {
-            "nonce": "d4fe",
-            "id": "chatcmpl-ec855684-8495-420d-8807-9259228ac717",
-            "object": "chat.completion.chunk",
-            "created": 1741199015,
-            "model": "llama-3.1-8b-instant",
-            "system_fingerprint": "fp_fd87957473",
-            "choices": [
-              {
-                "index": 0,
-                "delta": {},
-                "logprobs": null,
-                "finish_reason": "stop"
-              }
-            ],
-            "x_groq": {
-              "id": "req_01jnkrrz2ken1bej7emqf9j2af",
-              "usage": {
-                "queue_time": 0.291194089,
-                "prompt_tokens": 38,
-                "prompt_time": 0.002701306,
-                "completion_tokens": 256,
-                "completion_time": 0.341333333,
-                "total_tokens": 294,
-                "total_time": 0.344034639
-              }
-            }
-          }
-        ]
-      },
-
-      "metadata": {
-        "projectId": "proj_chat",
-        "projectName": "Chat Application",
-        "latency": 1244,
-        "tokens": { "input": 38, "output": 256, "total": 294 },
-        "cost": 0.0263,
-        "status": "success",
-        "provider_request_id": "req_01jnkrrz2ken1bej7emqf9j2af"
-      }
+    "metadata": {
+      "latency": 420,
+      "ttfb": 190,
+      "provider_latency": 400,
+      "tokens": {"input": 12, "output": 4, "total": 16},
+      "cost": 0.0000042,
+      "pricing_version": "2026.08.23",
+      "status": "success",
+      "path": "/v1/chat/completions",
+      "method": "POST",
+      "request_size": 152,
+      "response_size": 244,
+      "status_code": 200,
+      "provider_status_code": 200,
+      "error_count": 0,
+      "error_type": null,
+      "provider_error_count": 0,
+      "provider_error_type": null,
+      "provider_request_id": "provider-request-id"
     }
   }
-]
+}
+```
+
+When cost can be computed, `metadata.cost_breakdown` also itemizes uncached
+input, cache reads, cache writes, output, tool fees, total, completeness,
+missing dimensions, pricing version, whether an unknown-model assumption was
+used, and whether the value came from catalog arithmetic or an authoritative
+provider total. See [Pricing](PRICING.md) for the accounting contract.
+
+## Attribution headers
+
+The native middleware reads:
+
+- `x-project-id`
+- `x-organization-id` (and the `x-organisation-id` spelling where supported)
+- `x-user-id`
+- `x-experiment-id`
+
+These values are caller input, not trusted identity in transparent/dedicated
+mode. In native shared tenancy, project and organization are checked against the
+tenant derived from `x-noveum-api-key` before policy enforcement. Exporters
+should preserve that distinction.
+
+## Sensitive-data warning
+
+`DEBUG_METRICS=true` can print full prompts, model responses, tool arguments,
+and streaming chunks. Provider-specific `RUST_LOG=debug` targets can also log
+request bodies, response JSON, or stream chunks during ordinary tracing. The
+serializer normalizes some JSON shapes; it does **not** anonymize or remove
+confidential content. Therefore:
+
+- keep the console exporter off in normal production;
+- keep `RUST_LOG=info` in production and use narrowly targeted debug filters
+  only for brief, controlled sessions with protected log storage;
+- apply minimization/redaction before sending records to an external sink;
+- set retention and access controls appropriate for prompt content;
+- never emit provider, Noveum, or AWS credential headers;
+- configure ingress, reverse-proxy, APM, and Cloudflare logs to redact sensitive
+  headers independently; and
+- use synthetic, non-sensitive prompts during production probes.
+
+The built-in metrics record does not serialize request headers, but that does
+not prevent another proxy or debug layer from logging them.
+
+## Operational signals
+
+At minimum collect and alert on:
+
+- gateway and provider status code/error type;
+- total latency, provider latency, and TTFB;
+- restarts, panics, and sustained 5xx;
+- missing or incomplete token/cost dimensions;
+- Nova Guard blocks and policy/configuration rejections;
+- platform state/admission failures, especially fail-closed blocks;
+- abandoned reservations and settlement retry exhaustion; and
+- usage queue overflow/drop warnings.
+
+The Cloudflare Worker does not run native `MetricsExporter` plugins. Use
+`wrangler tail` for real-time diagnostics and enable Workers Logs (or an
+approved export) for persistent edge observability; see the
+[Worker runbook](CLOUDFLARE_WORKER.md#observability).

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -37,37 +37,23 @@ precedence and becomes the upstream `x-api-key`.
 on both runtimes. The gateway appends `/v1/messages`; use this only for a
 compatible proxy or a test server.
 
-## Current models and pricing
+## Model availability and pricing
 
-Examples below use `claude-sonnet-5`, an active Claude API model ID in
-[Anthropic's current model table](https://platform.claude.com/docs/en/about-claude/models/overview).
-The gateway does not restrict requests to this list, but Nova Guard catalog
-version `2026.08.23` includes these current high-value rows:
+Runnable examples below use `claude-haiku-4-5-20251001`, which passed buffered
+and streaming production probes on **2026-08-24**. Treat it as a dated verified
+example and check
+[Anthropic's current model table](https://platform.claude.com/docs/en/about-claude/models/overview)
+before deployment. Model IDs and account availability change independently of
+gateway releases; also check Anthropic's
+[deprecation table](https://platform.claude.com/docs/en/about-claude/model-deprecations).
 
-| Model | Availability note | Input | Output | Cache hit | 5m write | 1h write |
-|---|---|---:|---:|---:|---:|---:|
-| `claude-sonnet-5` | Active; $2/$10 launch pricing is permanent | $2.00 | $10.00 | $0.20 | $2.50 | $4.00 |
-| `claude-opus-5` | Active | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
-| `claude-opus-4-8` | Active | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
-| `claude-opus-4-5-20251101` | Active dated model ID | $5.00 | $25.00 | $0.50 | $6.25 | $10.00 |
-| `claude-fable-5` | Active | $10.00 | $50.00 | $1.00 | $12.50 | $20.00 |
-| `claude-mythos-5` | Active, limited/invitation-only availability | $10.00 | $50.00 | $1.00 | $12.50 | $20.00 |
-
-All values are USD per million tokens. Anthropic made Sonnet 5's $2/$10
-launch pricing permanent, so the catalog deliberately has no scheduled $3/$15
-increase. Model availability and IDs change independently of gateway releases;
-verify them against the
-[model table](https://platform.claude.com/docs/en/about-claude/models/overview)
-and [deprecation table](https://platform.claude.com/docs/en/about-claude/model-deprecations).
-
-These rates are policy estimates, not an invoice. Nova Guard models cache,
-US-only inference, and supported fast-mode premiums; batch discounts,
-negotiated pricing, taxes, and later provider changes can still differ. See the
-[pricing and accounting guide](../PRICING.md) and verify time-sensitive rates
-against [Anthropic's pricing page](https://platform.claude.com/docs/en/about-claude/pricing).
-
-For a simple uncached call with 1,000 input and 500 output tokens, the catalog
-estimate is `(1,000 / 1,000,000 × $2) + (500 / 1,000,000 × $10) = $0.007`.
+Nova Guard's versioned catalog models token, cache, eligible inference-geo, and
+supported fast-mode pricing. Catalog membership is not a promise that a model
+is available to the caller. These values are policy estimates, not an invoice;
+batch discounts, negotiated pricing, taxes, and later provider changes can
+differ. Use the single [pricing and accounting guide](../PRICING.md) for exact
+rows and verify time-sensitive values against
+[Anthropic's pricing page](https://platform.claude.com/docs/en/about-claude/pricing).
 
 ## Examples
 
@@ -79,7 +65,7 @@ curl http://localhost:3000/v1/chat/completions \
   -H "x-provider: anthropic" \
   -H "Authorization: Bearer $ANTHROPIC_API_KEY" \
   -d '{
-    "model": "claude-sonnet-5",
+    "model": "claude-haiku-4-5-20251001",
     "messages": [
       {"role": "system", "content": "Be concise."},
       {"role": "user", "content": "Explain atomic admission in one sentence."}
@@ -96,7 +82,7 @@ curl -N http://localhost:3000/v1/chat/completions \
   -H "x-provider: anthropic" \
   -H "x-api-key: $ANTHROPIC_API_KEY" \
   -d '{
-    "model": "claude-sonnet-5",
+    "model": "claude-haiku-4-5-20251001",
     "messages": [{"role": "user", "content": "Count to three."}],
     "max_completion_tokens": 64,
     "stream": true
@@ -120,7 +106,7 @@ const client = new OpenAI({
 });
 
 const response = await client.chat.completions.create({
-  model: "claude-sonnet-5",
+  model: "claude-haiku-4-5-20251001",
   messages: [{ role: "user", content: "Hello!" }],
   max_tokens: 128,
 });
@@ -132,7 +118,7 @@ console.log(response.choices[0].message.content);
 
 ```json
 {
-  "model": "claude-sonnet-5",
+  "model": "claude-haiku-4-5-20251001",
   "messages": [{"role": "user", "content": "What is the weather in Paris?"}],
   "max_output_tokens": 256,
   "tools": [
@@ -281,7 +267,7 @@ when those features are required.
 | Applicable enforcing/blocking strict Nova Guard cost cap without a positive explicit output limit | Gateway HTTP 400 with `error.code: "missing_output_limit"`, before admission or provider dispatch |
 
 Output-phase Nova Guard enforcement is skipped for all streaming providers in
-the current release; input-phase policies still run. For platform-managed
+v2.0.1; input-phase policies still run. For platform-managed
 metering, translated terminal usage is used to settle the reservation only when
 Anthropic supplied both input and output token counts. The buffered and stream
 converters preserve missing or partial usage as missing; they never manufacture

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -1,9 +1,12 @@
 # AWS Bedrock provider
 
 The Bedrock adapter accepts OpenAI-shaped **text chat-completions** requests and
-converts them to the AWS Bedrock Converse API. Buffered Converse responses and
-AWS EventStream responses are converted back to OpenAI chat-completions/SSE
-shapes.
+converts them to the AWS Bedrock Converse API. Buffered Converse responses are
+converted back to OpenAI chat-completions shape on both runtimes. Native Axum
+also supports ConverseStream and converts AWS EventStream frames to OpenAI SSE.
+The Cloudflare Worker does not implement Bedrock streaming in v2.0.1 and
+rejects `stream: true` with an OpenAI-shaped HTTP 400 and
+`error.code = "unsupported_feature"` before admission or AWS dispatch.
 
 This is not full OpenAI feature parity. In particular, OpenAI `tools`,
 `tool_calls`, multimodal parts, and provider-native Bedrock request extensions
@@ -21,12 +24,26 @@ x-aws-secret-access-key: <secret key>
 x-aws-region: us-east-1
 ```
 
-`x-aws-region` defaults to `us-east-1`. The Cloudflare Worker also accepts
-`x-aws-session-token` for temporary credentials. The native adapter does not
-yet have session-token parity.
+`x-aws-region` defaults to `us-east-1`. Both runtimes accept the optional
+`x-aws-session-token` header for temporary STS credentials.
 
-Grant the credentials only the model resources they need. The minimum runtime
-actions are normally:
+For STS credentials, add this header to the request; omit it for a long-lived
+access-key pair:
+
+```bash
+-H "x-aws-session-token: $AWS_SESSION_TOKEN"
+```
+
+These headers contain AWS signing credentials. Do **not** send them through the
+public/shared `gate.noveum.ai` service, a browser, or a gateway operated by a
+third party. Use a private gateway deployment you control, TLS, sensitive-header
+redaction at every proxy, and narrowly scoped credentials. Prefer short-lived
+session credentials on either runtime. Instance-role assumption is not
+implemented by this adapter; credentials still arrive in request headers.
+
+Grant the credentials only the model resources they need. Buffered requests
+need `bedrock:InvokeModel`; add `bedrock:InvokeModelWithResponseStream` only to
+credentials used for native streaming:
 
 ```json
 {
@@ -34,8 +51,7 @@ actions are normally:
   "Statement": [{
     "Effect": "Allow",
     "Action": [
-      "bedrock:InvokeModel",
-      "bedrock:InvokeModelWithResponseStream"
+      "bedrock:InvokeModel"
     ],
     "Resource": "<foundation-model-or-inference-profile-arn>"
   }]
@@ -54,7 +70,7 @@ The adapter currently maps:
 | `temperature` | `inferenceConfig.temperature` |
 | `top_p` | `inferenceConfig.topP` |
 | `stop` | `inferenceConfig.stopSequences` |
-| `stream: true` | Converse Stream + OpenAI SSE translation |
+| `stream: true` | Native only: ConverseStream + OpenAI SSE translation; Worker returns HTTP 400 `unsupported_feature` |
 
 Under an enforcing strict NovaGuard cost cap, output-limit aliases must agree,
 the body must be bounded JSON `/v1/chat/completions`, and provider-native fields
@@ -64,12 +80,12 @@ reserved by NovaGuard tied to the request that Bedrock receives.
 ## Example
 
 ```bash
-curl http://localhost:3000/v1/chat/completions \
+curl --fail-with-body http://127.0.0.1:3000/v1/chat/completions \
   -H 'content-type: application/json' \
   -H 'x-provider: bedrock' \
-  -H 'x-aws-access-key-id: YOUR_ACCESS_KEY' \
-  -H 'x-aws-secret-access-key: YOUR_SECRET_KEY' \
-  -H 'x-aws-region: us-east-1' \
+  -H "x-aws-access-key-id: $AWS_ACCESS_KEY_ID" \
+  -H "x-aws-secret-access-key: $AWS_SECRET_ACCESS_KEY" \
+  -H "x-aws-region: ${AWS_REGION:-us-east-1}" \
   -d '{
     "model": "amazon.nova-micro-v1:0",
     "max_tokens": 64,
@@ -116,22 +132,32 @@ settlement.
 
 ## Streaming and settlement
 
-Bedrock's `application/vnd.amazon.eventstream` response is preserved until the
-Bedrock decoder has reassembled complete AWS frames. The adapter then emits
-separate OpenAI SSE events and a final `[DONE]`. NovaGuard reads the native
-`inputTokens`, `outputTokens`, `cacheReadInputTokens`, and
+On the native gateway, Bedrock's `application/vnd.amazon.eventstream` response
+is preserved until the decoder has reassembled complete AWS frames. The adapter
+then emits separate OpenAI SSE events and a final `[DONE]`. NovaGuard reads the
+native `inputTokens`, `outputTokens`, `cacheReadInputTokens`, and
 `cacheWriteInputTokens` counters before the OpenAI response conversion so a
 strict reservation settles across every reported token/cache dimension.
+
+On the Worker, use buffered Bedrock requests only. A streaming request returns
+HTTP 400 `unsupported_feature` before any strict reservation or provider call;
+it is never silently downgraded to buffered mode.
 
 ## Known limitations
 
 - OpenAI function/tool definitions and Bedrock `toolUse`/`toolResult` blocks are
   not translated yet.
 - Multimodal Converse content is not exposed by the current OpenAI adapter.
-- Native temporary-session credential support is not yet at Worker parity.
-- A live Bedrock provider call still requires credentials and model entitlement;
-  the repository's hermetic tests cover signing, conversion, fragmented AWS
-  EventStream reassembly, SSE framing, and usage settlement without an AWS bill.
+- Worker Bedrock streaming is not implemented; native Bedrock streaming is.
+- Native and Worker signing both accept temporary session credentials; the
+  Worker remains buffered-only while native supports ConverseStream.
+- A live gateway Bedrock call still requires safely forwarding AWS credentials
+  plus model entitlement. The 2026-08-24 release-hardening audit confirmed
+  direct AWS Nova Micro buffered and streaming access, but did not forward
+  those AWS credentials through the gateway. Treat gateway-level Bedrock as
+  unverified in that audit rather than inferring a pass from direct AWS success.
+  Hermetic tests cover signing, buffered conversion, native fragmented AWS
+  EventStream reassembly/SSE framing, and usage settlement without an AWS bill.
 
 ## References
 

--- a/docs/providers/fireworks.md
+++ b/docs/providers/fireworks.md
@@ -1,322 +1,106 @@
-# Fireworks AI Provider
+# Fireworks AI provider
 
-## Configuration
+The `fireworks` route forwards OpenAI Chat Completions requests to
+`https://api.fireworks.ai/inference/v1`. It preserves buffered/SSE response
+shapes, the upstream `x-request-id`, and standard token usage for telemetry and
+Nova Guard settlement.
 
-### Request Headers
-```bash
-Authorization: Bearer $FIREWORKS_API_KEY
+## Authentication
+
+```text
 x-provider: fireworks
+Authorization: Bearer <Fireworks API key>
 ```
 
-## Popular Models
+The key is supplied on each request and forwarded only to Fireworks. Do not put
+it in gateway configuration, Worker secrets, source control, or logs.
 
-- **Llama 3.1 70B Instruct** - High performance general purpose ($0.90/M tokens)
-- **Mixtral MoE 8x7B Instruct** - Efficient multi-expert model ($0.50/M tokens)
-- **Llama 3.1 8B Instruct** - Fast, cost-effective option ($0.20/M tokens)
+## Buffered request
 
-See [Fireworks Model Library](https://fireworks.ai/models) for the complete list.
+This model ID was verified through the production gateway on **2026-08-24**:
 
-> **Note**: Vision models are currently not supported.
-
-## Usage Examples
-
-### Chat Completion
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
-  -H "Content-Type: application/json" \
+curl --fail-with-body http://127.0.0.1:3000/v1/chat/completions \
   -H "Authorization: Bearer $FIREWORKS_API_KEY" \
+  -H "Content-Type: application/json" \
   -H "x-provider: fireworks" \
   -d '{
-    "model": "accounts/fireworks/models/llama-v3p1-70b-instruct",
-    "messages": [
-      {"role": "user", "content": "What is the capital of France?"}
-    ],
-    "temperature": 0.7
+    "model": "accounts/fireworks/models/deepseek-v4-flash-0731",
+    "messages": [{"role": "user", "content": "Reply with one sentence."}],
+    "max_tokens": 64
   }'
 ```
 
-### Streaming Response
+## Streaming request
+
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
-  -H "Content-Type: application/json" \
+curl --no-buffer --fail-with-body \
+  http://127.0.0.1:3000/v1/chat/completions \
   -H "Authorization: Bearer $FIREWORKS_API_KEY" \
+  -H "Content-Type: application/json" \
   -H "x-provider: fireworks" \
   -d '{
-    "model": "accounts/fireworks/models/llama-v3p1-70b-instruct",
-    "messages": [
-      {"role": "user", "content": "Write a short poem about coding"}
-    ],
+    "model": "accounts/fireworks/models/deepseek-v4-flash-0731",
+    "messages": [{"role": "user", "content": "Count from one to three."}],
+    "max_tokens": 64,
     "stream": true
   }'
 ```
 
-### Multimodal Vision Model
-```bash
-curl --location 'localhost:3000/v1/chat/completions' \
---header 'Authorization: Bearer $FIREWORKS_API_KEY' \
---header 'Content-Type: application/json' \
---header 'x-provider: fireworks' \
---data '{
-    "model": "accounts/fireworks/models/llama-v3p2-11b-vision-instruct",
-    "messages": [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "type": "text",
-                    "text": "What'\''s in this image?"
-                },
-                {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": "https://upload.wikimedia.org/wikipedia/commons/f/f2/LPU-v1-die.jpg"
-                    }
-                }
-            ]
-        }
-    ],
-    "stream": false,
-    "max_tokens": 300
-}'
-```
+The dated ID is a verified example, not an evergreen inventory. Fireworks can
+add, rename, or retire models independently of this gateway. The older
+`llama-v3p1-*` examples and the catalogued
+`accounts/fireworks/models/llama-v3p3-70b-instruct` returned upstream 404s in
+the same 2026-08-24 audit and are intentionally not presented as runnable.
+That smoke observed provider-emitted terminal usage without adding OpenAI's
+undocumented-for-Fireworks `stream_options.include_usage` request field. Check
+the [Fireworks model library](https://fireworks.ai/models) before choosing a
+model.
 
-### TypeScript/JavaScript SDK
+## OpenAI SDK
+
 ```typescript
-import OpenAI from 'openai';
+import OpenAI from "openai";
 
 const client = new OpenAI({
   apiKey: process.env.FIREWORKS_API_KEY,
-  baseURL: 'http://localhost:3000/v1/',
-  defaultHeaders: { 'x-provider': 'fireworks' }
+  baseURL: "http://127.0.0.1:3000/v1",
+  defaultHeaders: { "x-provider": "fireworks" },
 });
 
-const response = await client.chat.completions.create({
-  model: 'accounts/fireworks/models/llama-v3p1-70b-instruct',
-  messages: [
-    { role: 'user', content: 'Explain quantum computing in simple terms' }
-  ],
-  temperature: 0.7
+const completion = await client.chat.completions.create({
+  model: "accounts/fireworks/models/deepseek-v4-flash-0731",
+  messages: [{ role: "user", content: "Reply with one sentence." }],
+  max_tokens: 64,
 });
 ```
 
-## Best Practices
+## Nova Guard and pricing
 
-1. **Model Selection**
-   - Use 70B models for complex tasks requiring deep reasoning
-   - Use 8B models for simple tasks and cost optimization
-   - Consider Mixtral models for specialized use cases
+- The gateway reads the standard Fireworks `usage.prompt_tokens`,
+  `completion_tokens`, and `total_tokens` fields.
+- Catalog family matching lets a dated suffix such as `-0731` use the reviewed
+  `accounts/fireworks/models/deepseek-v4-flash` pricing row when the boundary
+  match is valid.
+- A model absent from the catalog is conservatively estimated, not treated as
+  free. A fail-closed cost cap can reject an assumed model price.
+- An applicable strict cost cap requires a positive explicit output limit and
+  rejects request shapes that cannot be bounded before admission.
 
-2. **Performance**
-   - Enable streaming for real-time responses
-   - Set appropriate `max_tokens` limits
-   - Use proper error handling and retries
+Pricing is a policy estimate, not the Fireworks invoice. See
+[Pricing and cost accounting](../PRICING.md).
 
-## Resources
+## Troubleshooting
 
-- [Fireworks Documentation](https://docs.fireworks.ai)
-- [Model Library](https://fireworks.ai/models)
-- [Pricing Information](https://fireworks.ai/pricing)
+| Symptom | Check |
+|---|---|
+| 401/403 | The per-request Fireworks key and its account permissions. |
+| 404 | The exact live model ID; do not assume a catalog row proves upstream availability. |
+| 429 | Fireworks account/model limits and client retry/backoff. |
+| Stream has no authoritative usage | Treat it as a provider/model behavior change, record the smoke as incomplete, and expect Nova Guard to retain its conservative estimate. |
 
+## Primary references
 
-# Top AI Models
-
-1. **Llama 3.1 405B Instruct**  
-   - 131,072 Context  
-   - Serverless  
-
-2. **Llama 3.1 70B Instruct**  
-   - $0.90/M Tokens  
-   - 131,072 Context  
-   - Serverless  
-
-3. **Llama 3.1 8B Instruct**  
-   - $0.20/M Tokens  
-   - 131,072 Context  
-   - Serverless  
-
-4. **Llama 3.2 3B Instruct**  
-   - $0.20/M Tokens  
-   - 131,072 Context  
-   - Serverless  
-
-5. **Mixtral MoE 8x22B Instruct**  
-   - $0.90/M Tokens  
-   - 65,536 Context  
-   - Serverless  
-
-6. **Qwen2.5-Coder-32B-Instruct**  
-   - $0.90/M Tokens  
-   - 32,768 Context  
-   - Serverless  
-
-7. **Llama Guard 7B**  
-   - $0.20/M Tokens  
-   - 4,096 Context  
-
-8. **Zephyr 7B Beta**  
-   - $0.20/M Tokens  
-   - 4,096 Context  
-
-9. **Qwen2 72B Instruct**  
-    - $0.90/M Tokens  
-    - 32,768 Context  
-
-10. **Mixtral 8x22B Instruct v0.1**  
-    - $0.90/M Tokens  
-    - 65,536 Context  
-
-11. **CodeGemma 7B**  
-    - $0.20/M Tokens  
-    - 8,192 Context  
-
-12. **Mixtral MoE 8x7B Instruct**  
-    - $0.50/M Tokens  
-    - 32,768 Context  
-    - Serverless  
-
-13. **DeepSeek Coder 1.3B Base**  
-    - $0.20/M Tokens  
-    - 16,384 Context  
-
-14. **Yi-Large**  
-    - $3.00/M Tokens  
-    - 32,768 Context  
-    - Serverless  
-
-15. **Hermes 2 Pro Mistral 7B**  
-    - $0.20/M Tokens  
-
-16. **Llama 3 70B Instruct**  
-    - $0.90/M Tokens  
-    - 8,192 Context  
-    - Serverless  
-
-17. **Toppy M 7B**  
-    - $0.20/M Tokens  
-    - 32,768 Context  
-
-18. **Nous Hermes Llama2 7B**  
-    - $0.20/M Tokens  
-    - 4,096 Context  
-
-19. **Deepseek Coder 33B Instruct**  
-    - $0.90/M Tokens  
-    - 16,384 Context  
-
-20. **Chronos Hermes 13B v2**  
-    - $0.20/M Tokens  
-    - 4,096 Context  
-
-21. **Phind CodeLlama 34B v2**  
-    - $0.90/M Tokens  
-    - 16,384 Context  
-
-22. **Nous Hermes Llama2 70B**  
-    - $0.90/M Tokens  
-    - 4,096 Context  
-
-23. **Nous Hermes 2 - Mixtral 8x7B - DPO**  
-    - $0.50/M Tokens  
-    - 32,768 Context  
-
-24. **Qwen2.5 Math 72B Instruct**  
-    - $0.90/M Tokens  
-    - 4,096 Context  
-
-25. **Llama 2 70B Chat**  
-    - $0.90/M Tokens  
-    - 4,096 Context  
-
-26. **Mistral 7B Instruct v0.2**  
-    - $0.20/M Tokens  
-    - 32,768 Context  
-
-27. **StarCoder 7B**  
-    - $0.20/M Tokens  
-    - 8,192 Context  
-    - Serverless  
-
-28. **Code Llama 7B Python**  
-    - $0.20/M Tokens  
-    - 32,768 Context  
-
-29. **StarCoder2 15B**  
-    - $0.20/M Tokens  
-    - 16,384 Context  
-
-30. **Qwen2.5 14B Instruct**  
-    - $0.20/M Tokens  
-    - 32,768 Context  
-
-31. **Code Llama 34B Instruct**  
-    - $0.90/M Tokens  
-    - 32,768 Context  
-
-32. **Mixtral Moe 8x22B**  
-    - $0.90/M Tokens  
-    - 65,536 Context  
-
-33. **DeepSeek V2 Lite Chat**  
-    - 163,840 Context  
-
-34. **Phi 3.5 Vision Instruct**  
-    - 32,064 Context  
-    - Serverless  
-
-35. **Yi 6B**  
-    - $0.20/M Tokens  
-    - 4,096 Context  
-
-36. **MythoMax L2 13B**  
-    - $0.20/M Tokens  
-    - 4,096 Context  
-
-37. **StarCoder2 7B**  
-    - $0.20/M Tokens  
-    - 16,384 Context  
-
-38. **Code Llama 70B Instruct**  
-    - $0.90/M Tokens  
-    - 4,096 Context  
-
-39. **FireLLaVA-13B**  
-    - $0.20/M Tokens  
-    - 4,096 Context  
-
-40. **Stable Code 3B**  
-    - $0.20/M Tokens  
-
-41. **Deepseek Coder V2 Lite**  
-    - 163,840 Context  
-
-42. **Qwen2.5-Coder-7B-Instruct**  
-    - $0.20/M Tokens  
-    - 32,768 Context  
-
-43. **Qwen2.5 7B**  
-    - $0.20/M Tokens  
-    - 131,072 Context  
-
-44. **Llama 3.1 Nemotron 70B**  
-    - $0.90/M Tokens  
-    - 131,072 Context  
-
-45. **Llama 3.2 3B**  
-    - $0.20/M Tokens  
-    - 131,072 Context  
-
-46. **Capybara 34B**  
-    - $0.90/M Tokens  
-    - 200,000 Context  
-
-47. **Phind CodeLlama 34B Python v1**  
-    - $0.90/M Tokens  
-    - 16,384 Context  
-
-48. **Pythia 12B**  
-    - $0.20/M Tokens  
-    - 2,048 Context  
-
-49. **FireFunction V1**  
-    - 32,768 Context  
-    - Serverless  
+- [Fireworks documentation](https://docs.fireworks.ai/)
+- [Fireworks model library](https://fireworks.ai/models)
+- [Fireworks pricing](https://fireworks.ai/pricing)

--- a/docs/providers/groq.md
+++ b/docs/providers/groq.md
@@ -9,17 +9,15 @@ capability the upstream model lacks.
 
 ## Model availability
 
-The runnable examples and integration tests use `openai/gpt-oss-20b`, a Groq
-production model with a 131,072-token context window and 65,536 maximum output
-tokens. Groq changes production and preview availability independently of this
-gateway. Do not copy a frozen list from this repository; use Groq's
+The runnable examples and integration tests use `openai/gpt-oss-20b`, which
+passed buffered and streaming production probes on **2026-08-24**. Groq changes
+production and preview availability independently of this gateway. Do not copy
+a frozen list from this repository; use Groq's
 [current model table](https://console.groq.com/docs/models) and
 [deprecation history](https://console.groq.com/docs/deprecations), or query
 Groq's authenticated `/openai/v1/models` endpoint.
 
-Groq retired `llama-3.1-8b-instant` for affected plans on August 16, 2026 and
-names `openai/gpt-oss-20b` as its replacement. The examples below therefore do
-not use the older Llama, Mixtral, or preview slugs.
+The dated probe is not a guarantee of future model availability or limits.
 
 ## Configuration
 
@@ -130,13 +128,19 @@ async function main() {
 const stream = await client.chat.completions.create({
   model: "openai/gpt-oss-20b",
   messages: [{ role: "user", content: "Hello!" }],
-  stream: true
+  max_tokens: 64,
+  stream: true,
+  stream_options: { include_usage: true }
 });
 
 for await (const chunk of stream) {
   process.stdout.write(chunk.choices[0]?.delta?.content || '');
 }
 ```
+
+The terminal usage chunk can have an empty `choices` array. Requesting it is
+required for authoritative streaming settlement; the dated provider smoke
+requires both that usage and the final `[DONE]` marker.
 
 ## Response Format
 ```json

--- a/docs/providers/openai-compatible.md
+++ b/docs/providers/openai-compatible.md
@@ -23,10 +23,15 @@ API key>`. Token usage and per-request cost are extracted from the standard
 | `openrouter` | `https://openrouter.ai/api/v1` | `Bearer $OPENROUTER_API_KEY` | https://openrouter.ai/models |
 | `perplexity` | `https://api.perplexity.ai` | `Bearer $PERPLEXITY_API_KEY` | https://docs.perplexity.ai/guides/model-cards |
 
-> Pricing note: OpenRouter is a meta-router; the gateway prices a request only
-> when the upstream model id it returns is present in the pricing table.
-> Perplexity's per-request search fees are billed by Perplexity and are not
-> represented in the token cost.
+> Pricing note: OpenRouter is a meta-router. A returned model that matches the
+> catalog is priced normally; an unmatched model receives the conservative
+> assumed-model rate rather than $0. Perplexity's reported search count/context
+> tier is represented as a separate tool fee when it maps to a catalogued row.
+> These remain policy estimates, not provider invoices.
+
+Azure OpenAI is not a configured route in v2.0.1 on either the native gateway
+or Cloudflare Worker. Do not use `x-provider: azure`/`azure_openai` and assume
+that pricing-parser recognition creates a routable provider.
 
 ## Example (cURL)
 
@@ -37,13 +42,21 @@ curl http://localhost:3000/v1/chat/completions \
   -H "x-provider: google" \
   -H "Authorization: Bearer $GEMINI_API_KEY" \
   -d '{
-    "model": "gemini-2.5-flash",
+    "model": "gemini-2.5-flash-lite",
     "messages": [{"role": "user", "content": "Hello!"}],
     "max_tokens": 200
   }'
 ```
 
+`gemini-2.5-flash-lite` passed buffered and streaming production probes on
+**2026-08-24**. `openrouter/free` passed the same transparent routing matrix.
+These are dated proofs, not evergreen model inventories.
+
 Switch provider by changing `x-provider`, the API key, and the `model`:
+
+The DeepSeek request below illustrates that mechanical switch; DeepSeek was
+not part of the dated production matrix above. Verify the model ID and account
+access against DeepSeek before running it.
 
 ```bash
 # DeepSeek
@@ -51,7 +64,7 @@ curl http://localhost:3000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "x-provider: deepseek" \
   -H "Authorization: Bearer $DEEPSEEK_API_KEY" \
-  -d '{"model": "deepseek-chat", "messages": [{"role": "user", "content": "Hello!"}]}'
+  -d '{"model": "deepseek-chat", "messages": [{"role": "user", "content": "Hello!"}], "max_tokens": 64}'
 ```
 
 ## Example (OpenAI SDK)
@@ -60,14 +73,15 @@ curl http://localhost:3000/v1/chat/completions \
 import OpenAI from "openai";
 
 const client = new OpenAI({
-  apiKey: process.env.XAI_API_KEY,
+  apiKey: process.env.GEMINI_API_KEY,
   baseURL: "http://localhost:3000/v1",
-  defaultHeaders: { "x-provider": "xai" },
+  defaultHeaders: { "x-provider": "gemini" },
 });
 
 const completion = await client.chat.completions.create({
-  model: "grok-4.3",
+  model: "gemini-2.5-flash-lite",
   messages: [{ role: "user", content: "Hello!" }],
+  max_tokens: 64,
 });
 console.log(completion.choices[0].message);
 ```
@@ -79,7 +93,8 @@ Add the tracking headers to tag the per-request metrics: `x-project-id`,
 
 ## Implementation
 
-All of these are constructed by `openai_compatible(name)` in
-`src/providers/mod.rs` and served by `OpenAICompatibleProvider`. Adding another
-OpenAI-compatible vendor is a one-line addition there (name, base URL, and
-whether to strip the leading `/v1`).
+The native factory is `openai_compatible(name)` in `src/providers/mod.rs`; the
+shared/Worker route table is `routing::resolve_provider`. Adding a provider must
+update both tables, authentication/path behavior, metrics/pricing coverage,
+Worker and native tests, and this guide. A pricing-parser name alone does not
+make a provider routable.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -7,29 +7,21 @@ without changing their JSON shape. Model availability is determined by the
 caller's OpenAI project. Nova Guard pricing and strict admission use the
 gateway's versioned [pricing catalog](../PRICING.md).
 
-## Supported Models
+## Model availability and pricing
 
-### Current catalog rows
+`gpt-4o-mini`, used below, passed buffered and streaming production probes on
+**2026-08-24**. That result is a dated example, not a supported-model inventory:
+the caller's OpenAI project and OpenAI's current model lifecycle determine what
+it can invoke.
 
-- `gpt-5.6-luna` — $0.20/M input, $1.20/M output at standard short-context rates
-- `gpt-5.6-terra` — $2/M input, $12/M output
-- `gpt-5.6-sol` — promotional Standard rates of $4/M input, $0.40/M cached
-  input, $5/M cache writes, and $20/M output; above 272K input, the whole
-  request uses $8/$0.80/$10/$30 respectively
-- `gpt-5.6-cyber` — $12.50/M input, $75/M output
-- `gpt-5.6` and `daybreak-blue-latest` resolve to Sol for pricing;
-  `daybreak-red-latest` resolves to Cyber
-
-OpenAI says the Sol promotion is available at least through November 21, 2026.
-It has not published an exact end date or replacement rates, so Nova Guard does
-not schedule a rollback.
-
-The catalog also contains the supported GPT-4.x, reasoning, embedding, image,
-and audio rows listed in [Pricing](../PRICING.md). A model that OpenAI still
-accepts but the current catalog does not price is never treated as free: strict
-fail-closed cost caps reject it, while other modes use the conservative catalog
-maximum. See [OpenAI's current pricing](https://developers.openai.com/api/docs/pricing)
-for the upstream source of truth.
+The gateway pricing catalog includes many current and legacy OpenAI rows,
+aliases, cache rates, and long-context tiers. Catalog membership means the
+gateway can estimate a row; it does not prove upstream availability. An
+uncatalogued model is never treated as free: a fail-closed cost cap rejects the
+assumption, while other modes use the conservative catalog maximum. Use the
+single [pricing guide](../PRICING.md) for exact rates and update rules, and
+[OpenAI's pricing reference](https://developers.openai.com/api/docs/pricing) for
+the upstream source of truth.
 
 ## Configuration
 
@@ -53,9 +45,9 @@ curl -X POST http://localhost:3000/v1/chat/completions \
   -H "x-provider: openai" \
   -H "Authorization: Bearer $OPENAI_API_KEY" \
   -d '{
-    "model": "gpt-5.6-luna",
+    "model": "gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}],
-    "max_completion_tokens": 128,
+    "max_tokens": 128,
     "service_tier": "default"
   }'
 ```
@@ -67,9 +59,9 @@ curl -X POST http://localhost:3000/v1/chat/completions \
   -H "x-provider: openai" \
   -H "Authorization: Bearer $OPENAI_API_KEY" \
   -d '{
-    "model": "gpt-5.6-luna",
+    "model": "gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}],
-    "max_completion_tokens": 128,
+    "max_tokens": 128,
     "stream": true,
     "stream_options": {"include_usage": true}
   }'
@@ -89,12 +81,12 @@ const openai = new OpenAI({
 
 async function getChatCompletion() {
   const response = await openai.chat.completions.create({
-    model: "gpt-5.6-luna",
+    model: "gpt-4o-mini",
     messages: [{ role: "user", content: "Hello!" }],
-    max_completion_tokens: 128,
+    max_tokens: 128,
     service_tier: "default"
   });
-  console.log(response.data);
+  console.log(response.choices[0]?.message.content);
 }
 
 getChatCompletion();
@@ -121,9 +113,8 @@ getChatCompletion();
    - Log errors appropriately
 
 3. **Performance**
-   - Use an explicit output bound. GPT-5.6 uses `max_completion_tokens`; the
-     legacy `max_tokens` field is rejected by the upstream API for these models.
-   - Batch requests when possible
+   - Use an explicit output bound. Some reasoning/newer model families require
+     `max_completion_tokens`; follow the selected model's current OpenAI contract.
    - Implement caching for repeated requests
 
 When an enforcing/blocking strict Nova Guard cost cap applies, the gateway also
@@ -133,8 +124,7 @@ that cannot be reserved safely. Direct OpenAI strict traffic is pinned to
 
 ## Monitoring
 
-### Available Metrics (Coming Soon)
-- Request latency
-- Token usage
-- Error rates
-- Request volume
+The native telemetry record includes latency, TTFB, status, provider status,
+token usage, cost, and pricing completeness. See
+[Telemetry and log handling](../logs.md). For streaming settlement, request a
+terminal usage frame with `stream_options.include_usage`.

--- a/docs/providers/together.md
+++ b/docs/providers/together.md
@@ -1,439 +1,102 @@
-# Together AI Provider Integration
+# Together AI provider
 
-## Overview
-The Together AI provider enables access to multiple open-source models through Together's inference infrastructure.
+The `together` route forwards the gateway's OpenAI Chat Completions interface
+to `https://api.together.xyz`. Buffered and SSE responses remain
+OpenAI-compatible. If Together does not return an `x-request-id`, the gateway
+uses the response ID or generates a local request ID for tracing.
 
-## Base Configuration
-Refer to the provider implementation in `src/providers/together.rs`.
+## Authentication
 
-## Configuration
-
-### Request Headers
-```bash
-Authorization: Bearer tok_...
+```text
 x-provider: together
-Content-Type: application/json
+Authorization: Bearer <Together API key>
 ```
 
-## Supported Models
+Supply the provider key per request. It is not a Noveum API key and should not
+be stored in gateway/Worker configuration.
 
-### Open Source Models
-- Llama 2 (7B, 13B, 70B)
-- Mixtral-8x7B
-- CodeLlama
-- Stable LM
-- Yi Series
-- Qwen Series
+## Buffered request
 
-For a complete list of models, refer to the [Together AI Dedicated Models](https://docs.together.ai/docs/dedicated-models).
+This model ID was verified through the production gateway on **2026-08-24**:
 
-## API Endpoints
-
-### Chat Completions
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl --fail-with-body http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer $TOGETHER_API_KEY" \
   -H "Content-Type: application/json" \
   -H "x-provider: together" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
   -d '{
-    "model": "togethercomputer/llama-2-70b-chat",
-    "messages": [{"role": "user", "content": "Hello!"}]
+    "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    "messages": [{"role": "user", "content": "Reply with one sentence."}],
+    "max_tokens": 64
   }'
 ```
 
-### Streaming
+## Streaming request
+
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl --no-buffer --fail-with-body \
+  http://127.0.0.1:3000/v1/chat/completions \
+  -H "Authorization: Bearer $TOGETHER_API_KEY" \
   -H "Content-Type: application/json" \
   -H "x-provider: together" \
-  -H "Authorization: Bearer $TOGETHER_API_KEY" \
   -d '{
-    "model": "togethercomputer/llama-2-70b-chat",
-    "messages": [{"role": "user", "content": "Hello!"}],
+    "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    "messages": [{"role": "user", "content": "Count from one to three."}],
+    "max_tokens": 64,
     "stream": true
   }'
 ```
 
-## SDK Integration
+Together changes serverless/dedicated model availability independently of the
+gateway. The example is a dated production proof, not a frozen supported-model
+list; the 2026-08-24 smoke observed provider-emitted terminal usage without
+adding OpenAI's undocumented-for-Together `stream_options.include_usage`
+request field. Query Together's models endpoint or use its
+[current model reference](https://docs.together.ai/reference/models) before
+deployment.
 
-### Node.js (OpenAI SDK Compatible)
+## OpenAI SDK
+
 ```typescript
-import OpenAI from 'openai';
+import OpenAI from "openai";
 
-const together = new OpenAI({
+const client = new OpenAI({
   apiKey: process.env.TOGETHER_API_KEY,
-  baseURL: "http://localhost:3000/v1/",
-  defaultHeaders: { "x-provider": "together" }
+  baseURL: "http://127.0.0.1:3000/v1",
+  defaultHeaders: { "x-provider": "together" },
 });
 
-const response = await together.chat.completions.create({
-  model: "meta-llama/Meta-Llama-3-8B-Instruct-Turbo",
-  messages: [{ role: "user", content: "What are some fun things to do in New York?" }]
+const completion = await client.chat.completions.create({
+  model: "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+  messages: [{ role: "user", content: "Reply with one sentence." }],
+  max_tokens: 64,
 });
-
-console.log(response.choices[0].message.content);
 ```
 
-## Error Handling
+## Nova Guard and pricing
 
-| Error Code | Description | Solution |
-|------------|-------------|----------|
-| 401 | Invalid API key | Check your Together API key |
-| 429 | Rate limit exceeded | Implement backoff strategy |
-| 500 | Server error | Check server logs |
+The gateway reads Together's standard token usage and prices a case-insensitive
+model match against the versioned catalog. Model availability and price support
+are separate questions: a provider can serve a model that this catalog does not
+yet know, and a legacy catalog row does not prove the provider still serves it.
+Unknown models use a conservative estimate and can be rejected by a fail-closed
+cost cap.
 
-## Best Practices
+An applicable strict cost cap requires a positive explicit output limit and
+rejects unbounded provider-side work before admission. See
+[Nova Guard](../NOVA_GUARD.md) and [Pricing](../PRICING.md).
 
-1. **Model Selection**
-   - Choose appropriate model size
-   - Consider inference speed requirements
-   - Balance cost vs performance
+## Troubleshooting
 
-2. **Rate Limiting**
-   - Implement exponential backoff
-   - Monitor usage quotas
-   - Use streaming for long responses
+| Symptom | Check |
+|---|---|
+| 401/403 | The Together key and account permissions. |
+| 404 | The exact current model ID and whether it is serverless or dedicated. |
+| 429 | Together account/model limits and client retry/backoff. |
+| Missing streaming usage | Treat it as a provider/model behavior change, record the smoke as incomplete, and expect Nova Guard to retain its conservative estimate. |
 
-3. **Error Handling**
-   - Implement retry logic
-   - Handle timeouts gracefully
-   - Log errors appropriately
+## Primary references
 
-## Additional Resources
-
-- [Together AI Documentation](https://docs.together.ai)
-- [Available Models](https://docs.together.ai/reference/models)
-- [Pricing Information](https://www.together.ai/pricing) 
-
-### Serverless Models
-
-#### Meta
-- **Llama 3.1 8B Instruct Turbo**  
-  API Model: `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo`  
-  Context Length: 131072  
-  Quantization: FP8  
-
-- **Llama 3.1 70B Instruct Turbo**  
-  API Model: `meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo`  
-  Context Length: 131072  
-  Quantization: FP8  
-
-- **Llama 3.1 405B Instruct Turbo**  
-  API Model: `meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo`  
-  Context Length: 130815  
-  Quantization: FP8  
-
-- **Llama 3 8B Instruct Turbo**  
-  API Model: `meta-llama/Meta-Llama-3-8B-Instruct-Turbo`  
-  Context Length: 8192  
-  Quantization: FP8  
-
-- **Llama 3 70B Instruct Turbo**  
-  API Model: `meta-llama/Meta-Llama-3-70B-Instruct-Turbo`  
-  Context Length: 8192  
-  Quantization: FP8  
-
-- **Llama 3.2 3B Instruct Turbo**  
-  API Model: `meta-llama/Llama-3.2-3B-Instruct-Turbo`  
-  Context Length: 131072  
-  Quantization: FP16  
-
-- **Llama 3 8B Instruct Lite**  
-  API Model: `meta-llama/Meta-Llama-3-8B-Instruct-Lite`  
-  Context Length: 8192  
-  Quantization: INT4  
-
-- **Llama 3 70B Instruct Lite**  
-  API Model: `meta-llama/Meta-Llama-3-70B-Instruct-Lite`  
-  Context Length: 8192  
-  Quantization: INT4  
-
-- **Llama 3 8B Instruct Reference**  
-  API Model: `meta-llama/Llama-3-8b-chat-hf`  
-  Context Length: 8192  
-  Quantization: FP16  
-
-- **Llama 3 70B Instruct Reference**  
-  API Model: `meta-llama/Llama-3-70b-chat-hf`  
-  Context Length: 8192  
-  Quantization: FP16  
-
-#### Nvidia
-- **Llama 3.1 Nemotron 70B**  
-  API Model: `nvidia/Llama-3.1-Nemotron-70B-Instruct-HF`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### Qwen
-- **Qwen 2.5 Coder 32B Instruct**  
-  API Model: `Qwen/Qwen2.5-Coder-32B-Instruct`  
-  Context Length: 32769  
-  Quantization: FP16  
-
-- **Qwen 2.5 7B Instruct Turbo**  
-  API Model: `Qwen/Qwen2.5-7B-Instruct-Turbo`  
-  Context Length: 32768  
-  Quantization: FP8  
-
-- **Qwen 2.5 72B Instruct Turbo**  
-  API Model: `Qwen/Qwen2.5-72B-Instruct-Turbo`  
-  Context Length: 32768  
-  Quantization: FP8  
-
-- **Qwen 2 Instruct (72B)**  
-  API Model: `Qwen/Qwen2-72B-Instruct`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### Microsoft
-- **WizardLM-2 8x22B**  
-  API Model: `microsoft/WizardLM-2-8x22B`  
-  Context Length: 65536  
-  Quantization: FP16  
-
-#### Google
-- **Gemma 2 27B**  
-  API Model: `google/gemma-2-27b-it`  
-  Context Length: 8192  
-  Quantization: FP16  
-
-- **Gemma 2 9B**  
-  API Model: `google/gemma-2-9b-it`  
-  Context Length: 8192  
-  Quantization: FP16  
-
-- **Gemma Instruct (2B)**  
-  API Model: `google/gemma-2b-it`  
-  Context Length: 8192  
-  Quantization: FP16  
-
-#### Databricks
-- **DBRX Instruct**  
-  API Model: `databricks/dbrx-instruct`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### DeepSeek
-- **DeepSeek LLM Chat (67B)**  
-  API Model: `deepseek-ai/deepseek-llm-67b-chat`  
-  Context Length: 4096  
-  Quantization: FP16  
-
-#### Gryphe
-- **MythoMax-L2 (13B)**  
-  API Model: `Gryphe/MythoMax-L2-13b`  
-  Context Length: 4096  
-  Quantization: FP16  
-
-#### Mistralai
-- **Mistral (7B) Instruct**  
-  API Model: `mistralai/Mistral-7B-Instruct-v0.1`  
-  Context Length: 8192  
-  Quantization: FP16  
-
-- **Mistral (7B) Instruct v0.2**  
-  API Model: `mistralai/Mistral-7B-Instruct-v0.2`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-- **Mistral (7B) Instruct v0.3**  
-  API Model: `mistralai/Mistral-7B-Instruct-v0.3`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-- **Mixtral-8x7B Instruct (46.7B)**  
-  API Model: `mistralai/Mixtral-8x7B-Instruct-v0.1`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-- **Mixtral-8x22B Instruct (141B)**  
-  API Model: `mistralai/Mixtral-8x22B-Instruct-v0.1`  
-  Context Length: 65536  
-  Quantization: FP16  
-
-#### NousResearch
-- **Nous Hermes 2 - Mixtral 8x7B-DPO (46.7B)**  
-  API Model: `NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### Together
-- **StripedHyena Nous (7B)**  
-  API Model: `togethercomputer/StripedHyena-Nous-7B`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### Upstage
-- **Upstage SOLAR Instruct v1 (11B)**  
-  API Model: `upstage/SOLAR-10.7B-Instruct-v1.0`  
-  Context Length: 4096  
-  Quantization: FP16  
-
-### Dedicated Models
-
-#### 01.AI
-- **01-ai Yi Chat (34B)**  
-  API Model: `zero-one-ai/Yi-34B-Chat`  
-  Context Length: 4096  
-  Quantization: FP16  
-
-#### AllenAI
-- **OLMo Instruct (7B)**  
-  API Model: `allenai/OLMo-7B-Instruct`  
-  Context Length: 2048  
-  Quantization: FP16  
-
-#### Austism
-- **Chronos Hermes (13B)**  
-  API Model: `Austism/chronos-hermes-13b`  
-  Context Length: 2048  
-  Quantization: FP16  
-
-#### Carson
-- **carson ml318br**  
-  API Model: `carson/ml318br`  
-  Context Length: 8192  
-  Quantization: FP16  
-
-#### Cognitive Computations
-- **Dolphin 2.5 Mixtral 8x7B**  
-  API Model: `cognitivecomputations/dolphin-2.5-mixtral-8x7b`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### Databricks
-- **DBRX Instruct**  
-  API Model: `databricks/dbrx-instruct`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### DeepSeek
-- **DeepSeek LLM Chat (67B)**  
-  API Model: `deepseek-ai/deepseek-llm-67b-chat`  
-  Context Length: 4096  
-  Quantization: FP16  
-- **Deepseek Coder Instruct (33B)**  
-  API Model: `deepseek-ai/deepseek-coder-33b-instruct`  
-  Context Length: 16384  
-  Quantization: FP16  
-
-#### Garage-bAInd
-- **Platypus2 Instruct (70B)**  
-  API Model: `garage-bAInd/Platypus2-70B-instruct`  
-  Context Length: 4096  
-  Quantization: FP16  
-
-#### Google
-- **Gemma-2 Instruct (9B)**  
-  API Model: `google/gemma-2-9b-it`  
-  Context Length: 8192  
-  Quantization: FP16  
-- **Gemma-2 Instruct (27B)**  
-  API Model: `google/gemma-2-27b-it`  
-  Context Length: 8192  
-  Quantization: FP16  
-- **Gemma Instruct (2B)**  
-  API Model: `google/gemma-2b-it`  
-  Context Length: 8192  
-  Quantization: FP16  
-- **Gemma Instruct (7B)**  
-  API Model: `google/gemma-7b-it`  
-  Context Length: 8192  
-  Quantization: FP16  
-
-#### GradientAI
-- **Llama-3 70B Instruct Gradient 1048K**  
-  API Model: `gradientai/Llama-3-70B-Instruct-Gradient-1048k`  
-  Context Length: 1048576  
-  Quantization: FP16  
-
-#### Gryphe
-- **MythoMax-L2 (13B)**  
-  API Model: `Gryphe/MythoMax-L2-13b`  
-  Context Length: 4096  
-  Quantization: FP16  
-- **Gryphe MythoMax L2 Lite (13B)**  
-  API Model: `Gryphe/MythoMax-L2-13b-Lite`  
-  Context Length: 4096  
-  Quantization: FP16  
-
-#### Haotian Liu
-- **LLaVa-Next (Mistral-7B)**  
-  API Model: `llava-hf/llava-v1.6-mistral-7b-hf`  
-  Context Length: 4096  
-  Quantization: FP16  
-
-#### Hugging Face
-- **Zephyr-7B-ß**  
-  API Model: `HuggingFaceH4/zephyr-7b-beta`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### LM Sys
-- **Koala (7B)**  
-  API Model: `togethercomputer/Koala-7B`  
-  Context Length: 2048  
-  Quantization: FP16  
-- **Vicuna v1.3 (7B)**  
-  API Model: `lmsys/vicuna-7b-v1.3`  
-  Context Length: 2048  
-  Quantization: FP16  
-- **Vicuna v1.5 16K (13B)**  
-  API Model: `lmsys/vicuna-13b-v1.5-16k`  
-  Context Length: 16384  
-  Quantization: FP16  
-- **Vicuna v1.5 (13B)**  
-  API Model: `lmsys/vicuna-13b-v1.5`  
-  Context Length: 4096  
-  Quantization: FP16  
-
-#### Meta
-- **Code Llama Instruct (34B)**  
-  API Model: `codellama/CodeLlama-34b-Instruct-hf`  
-  Context Length: 16384  
-  Quantization: FP16  
-- **Meta Llama 3.2 90B Vision Instruct Turbo**  
-  API Model: `meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo`  
-  Context Length: 131072  
-  Quantization: FP16  
-- **Meta Llama 3.2 11B Vision Instruct Turbo**  
-  API Model: `meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo`  
-  Context Length: 131072  
-  Quantization: FP16  
-
-#### Microsoft
-- **WizardLM-2 (8x22B)**  
-  API Model: `microsoft/WizardLM-2-8x22B`  
-  Context Length: 65536  
-  Quantization: FP16  
-
-#### Mistralai
-- **Mistral (7B) Instruct v0.3**  
-  API Model: `mistralai/Mistral-7B-Instruct-v0.3`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### NousResearch
-- **Nous Hermes 2 - Mixtral 8x7B-DPO**  
-  API Model: `NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### Qwen
-- **Qwen 2 Instruct (72B)**  
-  API Model: `Qwen/Qwen2-72B-Instruct`  
-  Context Length: 32768  
-  Quantization: FP16  
-
-#### Upstage
-- **Upstage SOLAR Instruct v1 (11B)**  
-  API Model: `upstage/SOLAR-10.7B-Instruct-v1.0`  
-  Context Length: 4096  
-  Quantization: FP16  
-
-#### WizardLM
-- **WizardLM v1.2 (13B)**  
-  API Model: `WizardLM/WizardLM-13B-V1.2`  
-  Context Length: 4096  
-  Quantization: FP16  
-
+- [Together AI documentation](https://docs.together.ai/)
+- [Together model reference](https://docs.together.ai/reference/models)
+- [Together pricing](https://www.together.ai/pricing)

--- a/docs/telemetry-plugins.md
+++ b/docs/telemetry-plugins.md
@@ -1,15 +1,15 @@
-# Telemetry Exporters Guide
+# Telemetry exporter development
 
 This guide explains how per-request telemetry flows through the gateway and how to
 add a new exporter.
 
 ## Overview
 
-For every proxied request the gateway builds a [`RequestMetrics`] value (provider,
-model, token usage, cost, latency, status, request/response bodies, and tracking
-ids from headers). The [`MetricsRegistry`] fans that value out to every registered
-[`MetricsExporter`] concurrently, so adding a destination is just implementing one
-trait and registering it at startup.
+For every proxied request the native gateway builds a [`RequestMetrics`] value
+(provider, model, token usage, cost, latency, status, request/response bodies,
+and tracking IDs from headers). The [`MetricsRegistry`] spawns an independent
+export task for each registered [`MetricsExporter`]. Export failures are logged
+and do not change the already-proxied response.
 
 - `RequestMetrics` and the `to_otel_log` serializer — `src/telemetry/mod.rs`
 - `MetricsExporter` trait + `MetricsRegistry` — `src/telemetry/metrics.rs`
@@ -17,9 +17,9 @@ trait and registering it at startup.
   - **Console** (`src/telemetry/plugins/console.rs`) — pretty-prints metrics for
     local debugging. Enabled with `DEBUG_METRICS=true`.
 
-  Shipping traffic to an external observability backend (e.g. a Noveum trace
-  exporter) is a matter of implementing `MetricsExporter` and registering it in
-  `main.rs` — see below.
+Shipping records to an external observability backend requires implementing
+`MetricsExporter` and registering it in `main.rs` as described below. The
+Cloudflare Worker does not run these native exporters.
 
 ## The `MetricsExporter` trait
 
@@ -28,15 +28,20 @@ trait and registering it at startup.
 pub trait MetricsExporter: Send + Sync {
     /// Ship one request's metrics. Errors are logged by the registry and never
     /// block the proxied response.
-    async fn export_metrics(&self, metrics: RequestMetrics) -> Result<(), Box<dyn std::error::Error>>;
+    async fn export_metrics(
+        &self,
+        metrics: RequestMetrics,
+    ) -> Result<(), Box<dyn std::error::Error>>;
 
     /// Stable name for logging.
     fn name(&self) -> &str;
 }
 ```
 
-Exporters run off the request hot path, so a slow or failing exporter degrades
-telemetry only — never the proxied request.
+Exporter tasks run after recording is scheduled, so a slow or failing exporter
+degrades telemetry only. Add explicit timeouts, bounded queues, retry limits,
+and shutdown behavior when delivery guarantees matter; the trait itself does
+not provide them.
 
 ## Adding a new exporter
 
@@ -78,9 +83,16 @@ telemetry only — never the proxied request.
 
 ## Project / org attribution
 
-`RequestMetrics` carries `project_id`, `org_id`, `user_id`, and `experiment_id`,
-populated from the `x-project-id`, `x-organization-id`, `x-user-id`, and
-`x-experiment-id` request headers. Exporters should attribute data using these.
+`RequestMetrics` carries `project_id`, `org_id`, `user_id`, and `experiment_id`.
+In transparent and dedicated modes these begin as caller-supplied attribution,
+not authenticated identity. Native shared tenancy validates project and
+organization against the tenant derived from `x-noveum-api-key`. Exporters must
+preserve that distinction.
+
+Request and response bodies can contain prompts, tool arguments, personal data,
+and confidential output. Apply minimization/redaction before external export,
+keep provider/Noveum/AWS credentials out of records, and define retention and
+access controls. See [Telemetry and log handling](logs.md).
 
 [`RequestMetrics`]: ../src/telemetry/mod.rs
 [`MetricsRegistry`]: ../src/telemetry/metrics.rs

--- a/scripts/novaguard_mock_platform.py
+++ b/scripts/novaguard_mock_platform.py
@@ -723,8 +723,9 @@ class Handler(BaseHTTPRequestHandler):
             if isinstance(req.get("stream_options"), dict) else False
         )
         log("POST /v1/chat/completions (mock provider) model=%s stream=true "
-            "stream_options.include_usage=%s -> 200 text/event-stream"
-            % (model, include_usage))
+            "stream_options.include_usage=%s x_api_key_present=%s "
+            "-> 200 text/event-stream"
+            % (model, include_usage, bool(self.headers.get("x-api-key"))))
         if not include_usage:
             log("  !! include_usage was NOT set on the inbound request; the gateway "
                 "is supposed to FORCE it while metering")

--- a/scripts/novaguard_worker_e2e.sh
+++ b/scripts/novaguard_worker_e2e.sh
@@ -162,6 +162,7 @@ stream_request() {
   local agent_id="${1:-phase-stream}"
   curl -sN --max-time 30 "http://127.0.0.1:$GATEWAY_PORT/v1/chat/completions" \
     -H 'Authorization: Bearer sk-test' -H 'x-provider: openai' \
+    -H 'x-api-key: should-not-reach-openai' \
     -H "x-user-id: $agent_id" \
     -H 'Content-Type: application/json' \
     -d '{"model":"gpt-4o","stream":true,"max_tokens":4096,
@@ -484,6 +485,36 @@ say "Phase 1 -- allowed: admit, tee a real stream, settle at the TRUE usage"
 start_mock "$TMP/p1.log" MOCK_MAX_USD=1.0 MOCK_ENFORCEMENT_MODE=STRICT \
   MOCK_STREAM_PROMPT_TOKENS=11 MOCK_STREAM_COMPLETION_TOKENS=4
 start_wrangler
+LANDING_STATUS="$(curl -sS --max-time 30 -D "$TMP/p1-landing.headers" \
+  -o "$TMP/p1-landing.html" -w '%{http_code}' \
+  "http://127.0.0.1:$GATEWAY_PORT/")" || LANDING_STATUS="transport_error"
+LANDING_VERSION="$(awk -F '"' '/^version = / { print $2; exit }' "$ROOT/Cargo.toml")"
+[ "$LANDING_STATUS" = "200" ] \
+  && grep -qF 'Noveum AI Gateway' "$TMP/p1-landing.html" \
+  && grep -qF "Version <code>$LANDING_VERSION</code>" "$TMP/p1-landing.html" \
+  && grep -qF 'Runtime <code>cloudflare-worker</code>' "$TMP/p1-landing.html" \
+  && grep -qF '/v1/chat/completions' "$TMP/p1-landing.html" \
+  && pass "the public landing page identifies the Worker release and API route" \
+  || fail "the public landing page was missing or incomplete (HTTP $LANDING_STATUS)"
+grep -qi '^content-security-policy:.*default-src '\''none'\''' "$TMP/p1-landing.headers" \
+  && grep -qi '^x-content-type-options: *nosniff' "$TMP/p1-landing.headers" \
+  && grep -qi '^referrer-policy: *no-referrer' "$TMP/p1-landing.headers" \
+  && grep -qi '^content-type: *text/html; *charset=utf-8' "$TMP/p1-landing.headers" \
+  && grep -qi '^cache-control: *public, *max-age=300' "$TMP/p1-landing.headers" \
+  && pass "the Worker landing page carries the restrictive browser headers" \
+  || { fail "the Worker landing page security headers were incomplete"; sed 's/^/      /' "$TMP/p1-landing.headers"; }
+LANDING_HEAD_STATUS="$(curl -sS --max-time 30 --head -o "$TMP/p1-landing-head.headers" \
+  -w '%{http_code}' "http://127.0.0.1:$GATEWAY_PORT/")" || LANDING_HEAD_STATUS="transport_error"
+[ "$LANDING_HEAD_STATUS" = "200" ] \
+  && grep -qi '^content-type: *text/html; *charset=utf-8' "$TMP/p1-landing-head.headers" \
+  && grep -qi '^cache-control: *public, *max-age=300' "$TMP/p1-landing-head.headers" \
+  && grep -qi '^content-security-policy:.*default-src '\''none'\''' "$TMP/p1-landing-head.headers" \
+  && grep -qi '^x-content-type-options: *nosniff' "$TMP/p1-landing-head.headers" \
+  && grep -qi '^referrer-policy: *no-referrer' "$TMP/p1-landing-head.headers" \
+  && pass "HEAD / matches the native landing route and cache contract" \
+  || { fail "HEAD / did not match the landing contract (HTTP $LANDING_HEAD_STATUS)"; sed 's/^/      /' "$TMP/p1-landing-head.headers"; }
+refute_log "$TMP/p1.log" "GET /effective" \
+  "GET/HEAD landing requests bypassed the Noveum control plane"
 BODY="$(stream_request)"
 sleep 3   # settlement rides ctx.wait_until, so it lands after the body is done
 
@@ -496,6 +527,8 @@ expect_log "$TMP/p1.log" "POST /admit -> 200 ALLOWED" "POST /policies/admit rese
 # token counts and every streamed request settles at input + max_tokens.
 expect_log "$TMP/p1.log" "stream_options.include_usage=True" \
   "the Worker forced stream_options.include_usage on the upstream request"
+expect_log "$TMP/p1.log" "x_api_key_present=False" \
+  "a credential for another provider was stripped before OpenAI"
 # The payoff: settlement carries the REAL counts recovered by the tee, not the
 # 2 + 4096 estimate, and it arrives after the response body completed --
 # i.e. ctx.wait_until ran.
@@ -876,6 +909,44 @@ expect_strict_pre_admit_rejection "bedrock-region-priced-nova" bedrock "/v1/chat
   "application/json" \
   '{"model":"amazon.nova-pro-v1:0","max_tokens":64,"messages":[{"role":"user","content":"bounded"}]}' \
   "source-region-priced Bedrock Nova under a strict cap"
+BEDROCK_STREAM_BODY="$TMP/p9-strict-bedrock-stream.body"
+BEDROCK_STREAM_HEADERS="$TMP/p9-strict-bedrock-stream.headers"
+BEDROCK_STREAM_STATUS="$(curl -sS --max-time 30 -D "$BEDROCK_STREAM_HEADERS" \
+  -o "$BEDROCK_STREAM_BODY" -w '%{http_code}' \
+  "http://127.0.0.1:$GATEWAY_PORT/v1/chat/completions" \
+  -H 'x-provider: bedrock' \
+  -H 'x-aws-access-key-id: AKIATEST' \
+  -H 'x-aws-secret-access-key: worker-test-secret' \
+  -H 'x-aws-region: us-east-1' \
+  -H 'content-type: application/json' \
+  --data-binary '{"model":"global.anthropic.claude-sonnet-4-5-20250929-v1:0","stream":true,"max_tokens":64,"messages":[{"role":"user","content":"bounded"}]}'
+)" || BEDROCK_STREAM_STATUS="transport_error"
+[ "$BEDROCK_STREAM_STATUS" = "400" ] \
+  && grep -qi '^content-type: *application/json' "$BEDROCK_STREAM_HEADERS" \
+  && grep -q '"type":"invalid_request_error"' "$BEDROCK_STREAM_BODY" \
+  && grep -q '"param":null' "$BEDROCK_STREAM_BODY" \
+  && grep -q '"code":"unsupported_feature"' "$BEDROCK_STREAM_BODY" \
+  && grep -q 'Cloudflare Worker' "$BEDROCK_STREAM_BODY" \
+  && pass "Worker Bedrock streaming is rejected explicitly before admission" \
+  || { fail "Worker Bedrock streaming should return HTTP 400 unsupported_feature"; sed 's/^/      /' "$BEDROCK_STREAM_BODY"; }
+BEDROCK_REGION_BODY="$TMP/p9-strict-bedrock-region.body"
+BEDROCK_REGION_HEADERS="$TMP/p9-strict-bedrock-region.headers"
+BEDROCK_REGION_STATUS="$(curl -sS --max-time 30 -D "$BEDROCK_REGION_HEADERS" \
+  -o "$BEDROCK_REGION_BODY" -w '%{http_code}' \
+  "http://127.0.0.1:$GATEWAY_PORT/v1/chat/completions" \
+  -H 'x-provider: bedrock' \
+  -H 'x-aws-access-key-id: AKIATEST' \
+  -H 'x-aws-secret-access-key: worker-test-secret' \
+  -H 'x-aws-region: us-east-1.amazonaws.com@attacker.invalid' \
+  -H 'content-type: application/json' \
+  --data-binary '{"model":"global.anthropic.claude-sonnet-4-5-20250929-v1:0","max_tokens":64,"messages":[{"role":"user","content":"bounded"}]}'
+)" || BEDROCK_REGION_STATUS="transport_error"
+[ "$BEDROCK_REGION_STATUS" = "400" ] \
+  && grep -qi '^content-type: *application/json' "$BEDROCK_REGION_HEADERS" \
+  && grep -q '"type":"invalid_request_error"' "$BEDROCK_REGION_BODY" \
+  && grep -q 'x-aws-region' "$BEDROCK_REGION_BODY" \
+  && pass "Worker rejects malformed Bedrock regions before admission" \
+  || { fail "Worker malformed Bedrock region should return HTTP 400 invalid_request_error"; sed 's/^/      /' "$BEDROCK_REGION_BODY"; }
 expect_strict_pre_admit_rejection "divergent-output-limits" groq "/v1/chat/completions" \
   "application/json" \
   '{"model":"openai/gpt-oss-20b","max_tokens":64,"max_output_tokens":65,"messages":[{"role":"user","content":"bounded"}]}' \

--- a/scripts/novaguard_worker_e2e.sh
+++ b/scripts/novaguard_worker_e2e.sh
@@ -929,6 +929,21 @@ BEDROCK_STREAM_STATUS="$(curl -sS --max-time 30 -D "$BEDROCK_STREAM_HEADERS" \
   && grep -q 'Cloudflare Worker' "$BEDROCK_STREAM_BODY" \
   && pass "Worker Bedrock streaming is rejected explicitly before admission" \
   || { fail "Worker Bedrock streaming should return HTTP 400 unsupported_feature"; sed 's/^/      /' "$BEDROCK_STREAM_BODY"; }
+BEDROCK_STREAM_TYPE_BODY="$TMP/p9-strict-bedrock-stream-type.body"
+BEDROCK_STREAM_TYPE_STATUS="$(curl -sS --max-time 30 -o "$BEDROCK_STREAM_TYPE_BODY" -w '%{http_code}' \
+  "http://127.0.0.1:$GATEWAY_PORT/v1/chat/completions" \
+  -H 'x-provider: bedrock' \
+  -H 'x-aws-access-key-id: AKIATEST' \
+  -H 'x-aws-secret-access-key: worker-test-secret' \
+  -H 'x-aws-region: us-east-1' \
+  -H 'content-type: application/json' \
+  --data-binary '{"model":"global.anthropic.claude-sonnet-4-5-20250929-v1:0","stream":"false","max_tokens":64,"messages":[{"role":"user","content":"bounded"}]}'
+)" || BEDROCK_STREAM_TYPE_STATUS="transport_error"
+[ "$BEDROCK_STREAM_TYPE_STATUS" = "400" ] \
+  && grep -q '"type":"invalid_request_error"' "$BEDROCK_STREAM_TYPE_BODY" \
+  && grep -q 'Boolean' "$BEDROCK_STREAM_TYPE_BODY" \
+  && pass "Worker rejects a non-Boolean Bedrock stream field before admission" \
+  || { fail "Worker non-Boolean Bedrock stream should return HTTP 400"; sed 's/^/      /' "$BEDROCK_STREAM_TYPE_BODY"; }
 BEDROCK_REGION_BODY="$TMP/p9-strict-bedrock-region.body"
 BEDROCK_REGION_HEADERS="$TMP/p9-strict-bedrock-region.headers"
 BEDROCK_REGION_STATUS="$(curl -sS --max-time 30 -D "$BEDROCK_REGION_HEADERS" \

--- a/scripts/validate_docker_release.sh
+++ b/scripts/validate_docker_release.sh
@@ -1,0 +1,454 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(CDPATH= cd -- "${script_dir}/.." && pwd)"
+docker_context_validation_tmp=""
+docker_runtime_validation_container=""
+release_provenance_validation_tmp=""
+
+package_version() {
+  local version
+  version="$({
+    awk '
+      /^\[package\][[:space:]]*$/ { in_package = 1; next }
+      /^\[/ { if (in_package) exit; next }
+      in_package && /^[[:space:]]*version[[:space:]]*=/ {
+        line = $0
+        sub(/^[^"]*"/, "", line)
+        sub(/".*$/, "", line)
+        print line
+        exit
+      }
+    ' "${repository_root}/Cargo.toml"
+  } || true)"
+
+  if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+    echo "Could not read a valid package version from Cargo.toml" >&2
+    return 1
+  fi
+  printf '%s\n' "${version}"
+}
+
+release_mode() {
+  local event_name="$1"
+  local git_ref="$2"
+
+  if [[ "${event_name}" == "push" && "${git_ref}" == refs/tags/v* ]]; then
+    local version expected_ref
+    version="$(package_version)"
+    expected_ref="refs/tags/v${version}"
+    if [[ "${git_ref}" != "${expected_ref}" ]]; then
+      echo "Release tag ${git_ref} does not match Cargo package version v${version}" >&2
+      return 1
+    fi
+    printf 'release\n'
+  else
+    printf 'build\n'
+  fi
+}
+
+self_test_release_mode() {
+  local version
+  version="$(package_version)"
+
+  [[ "$(release_mode push "refs/tags/v${version}")" == "release" ]]
+  [[ "$(release_mode push refs/heads/main)" == "build" ]]
+  [[ "$(release_mode pull_request refs/pull/123/merge)" == "build" ]]
+  [[ "$(release_mode workflow_dispatch refs/heads/main)" == "build" ]]
+
+  if release_mode push "refs/tags/v${version}-mismatch" >/dev/null 2>&1; then
+    echo "Mismatched release tag was accepted" >&2
+    return 1
+  fi
+}
+
+assert_release_provenance() {
+  local candidate_ref="$1"
+  local main_ref="$2"
+  local git_repository="${3:-${repository_root}}"
+  local candidate_sha main_sha
+
+  candidate_sha="$(git -C "${git_repository}" rev-parse --verify "${candidate_ref}^{commit}")" || {
+    echo "Release candidate ref does not resolve to a commit: ${candidate_ref}" >&2
+    return 1
+  }
+  main_sha="$(git -C "${git_repository}" rev-parse --verify "${main_ref}^{commit}")" || {
+    echo "Trusted main ref does not resolve to a commit: ${main_ref}" >&2
+    return 1
+  }
+  if ! git -C "${git_repository}" merge-base --is-ancestor "${candidate_sha}" "${main_sha}"; then
+    echo "Release commit ${candidate_sha} is not merged into trusted main ${main_sha}" >&2
+    return 1
+  fi
+  echo "Release commit ${candidate_sha} is contained in trusted main ${main_sha}"
+}
+
+self_test_release_provenance() {
+  local validation_tmp root_commit main_commit side_commit failure_output
+  validation_tmp="$(mktemp -d "${TMPDIR:-/tmp}/noveum-release-provenance.XXXXXX")"
+  release_provenance_validation_tmp="${validation_tmp}"
+  cleanup_release_provenance_validation() {
+    case "${release_provenance_validation_tmp}" in
+      "${TMPDIR:-/tmp}"/noveum-release-provenance.*)
+        rm -rf -- "${release_provenance_validation_tmp}"
+        release_provenance_validation_tmp=""
+        ;;
+      "") ;;
+      *)
+        echo "Refusing to remove unexpected provenance path: ${release_provenance_validation_tmp}" >&2
+        ;;
+    esac
+  }
+  trap cleanup_release_provenance_validation EXIT HUP INT TERM
+
+  git -C "${validation_tmp}" init --quiet
+  git -C "${validation_tmp}" config user.name "Noveum release validator"
+  git -C "${validation_tmp}" config user.email "release-validator@example.invalid"
+  : >"${validation_tmp}/root"
+  git -C "${validation_tmp}" add root
+  git -C "${validation_tmp}" commit --quiet -m root
+  git -C "${validation_tmp}" branch -M main
+  root_commit="$(git -C "${validation_tmp}" rev-parse HEAD)"
+
+  : >"${validation_tmp}/main"
+  git -C "${validation_tmp}" add main
+  git -C "${validation_tmp}" commit --quiet -m main
+  main_commit="$(git -C "${validation_tmp}" rev-parse HEAD)"
+
+  git -C "${validation_tmp}" switch --quiet --detach "${root_commit}"
+  : >"${validation_tmp}/side"
+  git -C "${validation_tmp}" add side
+  git -C "${validation_tmp}" commit --quiet -m side
+  side_commit="$(git -C "${validation_tmp}" rev-parse HEAD)"
+
+  assert_release_provenance "${main_commit}" "${main_commit}" "${validation_tmp}"
+  assert_release_provenance "${root_commit}" "${main_commit}" "${validation_tmp}"
+  if failure_output="$(assert_release_provenance "${side_commit}" "${main_commit}" "${validation_tmp}" 2>&1)"; then
+    echo "An unmerged release commit passed the provenance guard" >&2
+    return 1
+  fi
+  if [[ "${failure_output}" != *"not merged into trusted main"* ]]; then
+    echo "The unmerged release commit failed for an unexpected reason: ${failure_output}" >&2
+    return 1
+  fi
+
+  cleanup_release_provenance_validation
+  trap - EXIT HUP INT TERM
+}
+
+validate_workflow_wiring() {
+  local docker_workflow provider_workflow classifier_line fetch_line provenance_line runtime_line first_publish_line
+  local build_action_count revision_arg_count smoke_if_line steps_line checkout_line first_secret_line
+  docker_workflow="${repository_root}/.github/workflows/docker-build.yml"
+  provider_workflow="${repository_root}/.github/workflows/provider-smoke.yml"
+
+  classifier_line="$(grep -n -m1 'validate_docker_release.sh mode' "${docker_workflow}" | cut -d: -f1 || true)"
+  if [[ -z "${classifier_line}" ]]; then
+    echo "Docker workflow does not invoke the release-mode validator" >&2
+    return 1
+  fi
+
+  fetch_line="$(grep -n -m1 'git fetch --no-tags origin' "${docker_workflow}" | cut -d: -f1 || true)"
+  provenance_line="$(grep -n -m1 'validate_docker_release.sh provenance HEAD refs/remotes/origin/main' "${docker_workflow}" | cut -d: -f1 || true)"
+  runtime_line="$(grep -n -m1 'validate_docker_release.sh runtime-image' "${docker_workflow}" | cut -d: -f1 || true)"
+  first_publish_line="$(grep -En -m1 'push:[[:space:]]*true|\$\{\{[[:space:]]*secrets\.' "${docker_workflow}" | cut -d: -f1 || true)"
+  if [[ -z "${fetch_line}" || -z "${provenance_line}" || -z "${runtime_line}" || -z "${first_publish_line}" ]] ||
+    (( fetch_line >= provenance_line || provenance_line >= first_publish_line || runtime_line >= first_publish_line ))
+  then
+    echo "Docker publication must follow runtime validation and an explicit trusted-main provenance check" >&2
+    return 1
+  fi
+
+  build_action_count="$(grep -c 'uses: docker/build-push-action@' "${docker_workflow}" || true)"
+  revision_arg_count="$(grep -c -F 'REVISION=${{ github.sha }}' "${docker_workflow}" || true)"
+  if [[ "${build_action_count}" -eq 0 || "${revision_arg_count}" -ne "${build_action_count}" ]]; then
+    echo "Every Docker build must receive github.sha as its OCI revision" >&2
+    return 1
+  fi
+
+  # Registry credentials and every push-capable Docker step must be guarded by
+  # the validated release output, rather than by a mutable branch name.
+  if ! awk '
+    function finish_step() {
+      if (sensitive && !guarded) {
+        print "Sensitive Docker workflow step is not release-guarded: " step > "/dev/stderr"
+        bad = 1
+      }
+      sensitive = 0
+      guarded = 0
+      step = "<unnamed>"
+    }
+    /^      - / {
+      finish_step()
+      step = $0
+    }
+    /push:[[:space:]]*true/ || /\$\{\{[[:space:]]*secrets\./ { sensitive = 1 }
+    /if:[[:space:]]*steps\.release\.outputs\.publish[[:space:]]*==[[:space:]]*'"'"'true'"'"'/ {
+      guarded = 1
+    }
+    END {
+      finish_step()
+      exit bad
+    }
+  ' "${docker_workflow}"
+  then
+    return 1
+  fi
+
+  smoke_if_line="$(grep -n -m1 "if: github.ref == 'refs/heads/main'" "${provider_workflow}" | cut -d: -f1 || true)"
+  steps_line="$(grep -n -m1 '^[[:space:]]*steps:' "${provider_workflow}" | cut -d: -f1 || true)"
+  checkout_line="$(grep -n -m1 'uses: actions/checkout@' "${provider_workflow}" | cut -d: -f1 || true)"
+  first_secret_line="$(grep -n -m1 -F '${{ secrets.' "${provider_workflow}" | cut -d: -f1 || true)"
+  if [[ -z "${smoke_if_line}" || -z "${steps_line}" || -z "${checkout_line}" || -z "${first_secret_line}" ]] ||
+    (( smoke_if_line >= steps_line || steps_line >= checkout_line || checkout_line >= first_secret_line ))
+  then
+    echo "Provider smoke must reject non-main refs at the job boundary before checkout or secrets" >&2
+    return 1
+  fi
+
+  if awk '
+    /uses: actions\/checkout@/ { in_checkout = 1; next }
+    in_checkout && /^      - / { exit(found_ref ? 0 : 1) }
+    in_checkout && /^[[:space:]]+ref:/ { found_ref = 1 }
+    END { if (in_checkout) exit(found_ref ? 0 : 1) }
+  ' "${provider_workflow}"
+  then
+    echo "Provider smoke checkout overrides the trusted event SHA" >&2
+    return 1
+  fi
+
+  self_test_release_mode
+  self_test_release_provenance
+  echo "Workflow release and secret-ref guards are wired correctly"
+}
+
+validate_context() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required for build-context validation" >&2
+    return 1
+  fi
+  if ! docker buildx version >/dev/null 2>&1; then
+    echo "Docker Buildx is required for build-context validation" >&2
+    return 1
+  fi
+
+  local validation_tmp context_dir positive_output positive_log
+  validation_tmp="$(mktemp -d "${TMPDIR:-/tmp}/noveum-docker-context.XXXXXX")"
+  docker_context_validation_tmp="${validation_tmp}"
+  context_dir="${validation_tmp}/context"
+  positive_output="${validation_tmp}/allowed-output"
+  positive_log="${validation_tmp}/allowed-build.log"
+  mkdir -p "${context_dir}"
+
+  cleanup_context_validation() {
+    case "${docker_context_validation_tmp}" in
+      "${TMPDIR:-/tmp}"/noveum-docker-context.*)
+        rm -rf -- "${docker_context_validation_tmp}"
+        docker_context_validation_tmp=""
+        ;;
+      "") ;;
+      *)
+        echo "Refusing to remove unexpected validation path: ${docker_context_validation_tmp}" >&2
+        ;;
+    esac
+  }
+  trap cleanup_context_validation EXIT HUP INT TERM
+
+  cp "${repository_root}/.dockerignore" "${context_dir}/.dockerignore"
+  cp "${repository_root}/Cargo.toml" "${context_dir}/Cargo.toml"
+  cp "${repository_root}/Cargo.lock" "${context_dir}/Cargo.lock"
+  cp -R "${repository_root}/src" "${context_dir}/src"
+  cp -R "${repository_root}/schema" "${context_dir}/schema"
+  cp -R "${repository_root}/pricing" "${context_dir}/pricing"
+
+  local allowed_dockerfile
+  allowed_dockerfile=$'FROM scratch\nCOPY Cargo.toml /Cargo.toml\nCOPY Cargo.lock /Cargo.lock\nCOPY src /src\nCOPY schema /schema\nCOPY pricing /pricing'
+  if ! printf '%s\n' "${allowed_dockerfile}" |
+    docker buildx build --no-cache --progress=plain \
+      --output "type=local,dest=${positive_output}" \
+      --file - "${context_dir}" >"${positive_log}" 2>&1
+  then
+    echo "The Docker build context omitted a required release input" >&2
+    sed 's/^/  /' "${positive_log}" >&2
+    return 1
+  fi
+
+  local sentinel sentinel_path denied_log denied_output denied_dockerfile
+  for sentinel in \
+    ".env.test" \
+    ".dev.vars" \
+    "tests/.env.test" \
+    ".wrangler/session.json" \
+    "unlisted-release-sentinel.txt"
+  do
+    sentinel_path="${context_dir}/${sentinel}"
+    mkdir -p "$(dirname -- "${sentinel_path}")"
+    : >"${sentinel_path}"
+    denied_log="${validation_tmp}/denied-$(printf '%s' "${sentinel}" | tr '/.' '__').log"
+    denied_output="${validation_tmp}/denied-output-$(printf '%s' "${sentinel}" | tr '/.' '__')"
+    denied_dockerfile="$(printf 'FROM scratch\nCOPY %s /forbidden-sentinel\n' "${sentinel}")"
+
+    if printf '%s\n' "${denied_dockerfile}" |
+      docker buildx build --no-cache --progress=plain \
+        --output "type=local,dest=${denied_output}" \
+        --file - "${context_dir}" >"${denied_log}" 2>&1
+    then
+      echo "Forbidden Docker context path was copyable: ${sentinel}" >&2
+      return 1
+    fi
+
+    if ! grep -F "${sentinel}" "${denied_log}" >/dev/null 2>&1 ||
+      ! grep -Eiq 'not found|excluded.*dockerignore|failed to calculate checksum' "${denied_log}"
+    then
+      echo "Docker rejected ${sentinel} for an unexpected reason" >&2
+      sed 's/^/  /' "${denied_log}" >&2
+      return 1
+    fi
+  done
+
+  cleanup_context_validation
+  trap - EXIT HUP INT TERM
+  echo "Docker context contains only the required release inputs"
+}
+
+validate_runtime_image() {
+  local image="$1"
+  local expected_revision="${2:-}"
+  local expected_version configured_user runtime_uid runtime_gid revision_label image_platform
+  local container_name port_mapping host_port body
+
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required for runtime-image validation" >&2
+    return 1
+  fi
+  expected_version="$(package_version)"
+  image_platform="$(docker image inspect --format '{{.Os}}/{{.Architecture}}' "${image}")"
+  configured_user="$(docker image inspect --format '{{.Config.User}}' "${image}")"
+  if [[ "${configured_user}" != "65532:65532" ]]; then
+    echo "Runtime image must use fixed UID:GID 65532:65532, got: ${configured_user:-<empty>}" >&2
+    return 1
+  fi
+
+  runtime_uid="$(docker run --rm --platform "${image_platform}" --entrypoint /usr/bin/id "${image}" -u)"
+  runtime_gid="$(docker run --rm --platform "${image_platform}" --entrypoint /usr/bin/id "${image}" -g)"
+  if [[ "${runtime_uid}" != "65532" || "${runtime_gid}" != "65532" ]]; then
+    echo "Runtime image resolved to unexpected UID:GID ${runtime_uid}:${runtime_gid}" >&2
+    return 1
+  fi
+  if [[ "$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.version"}}' "${image}")" != "${expected_version}" ]]; then
+    echo "Runtime image OCI version label does not match Cargo ${expected_version}" >&2
+    return 1
+  fi
+  revision_label="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "${image}")"
+  if [[ -z "${revision_label}" || "${revision_label}" == "<no value>" ]]; then
+    echo "Runtime image has no OCI source revision" >&2
+    return 1
+  fi
+  if [[ -n "${expected_revision}" && "${revision_label}" != "${expected_revision}" ]]; then
+    echo "Runtime image OCI revision ${revision_label} does not match ${expected_revision}" >&2
+    return 1
+  fi
+
+  container_name="noveum-runtime-validation-$$-${RANDOM}"
+  docker_runtime_validation_container="${container_name}"
+  cleanup_runtime_validation() {
+    if [[ -n "${docker_runtime_validation_container}" ]]; then
+      docker rm --force "${docker_runtime_validation_container}" >/dev/null 2>&1 || true
+      docker_runtime_validation_container=""
+    fi
+  }
+  trap cleanup_runtime_validation EXIT HUP INT TERM
+
+  docker run --detach \
+    --name "${container_name}" \
+    --platform "${image_platform}" \
+    --publish 127.0.0.1::3000 \
+    --read-only \
+    --cap-drop ALL \
+    --security-opt no-new-privileges \
+    "${image}" >/dev/null
+  port_mapping="$(docker port "${container_name}" 3000/tcp | head -n 1)"
+  host_port="${port_mapping##*:}"
+  if [[ ! "${host_port}" =~ ^[0-9]+$ ]]; then
+    echo "Could not resolve the validation container's published port" >&2
+    docker logs "${container_name}" >&2 || true
+    return 1
+  fi
+
+  body=""
+  for _attempt in {1..60}; do
+    if body="$(curl --fail --silent --show-error "http://127.0.0.1:${host_port}/health" 2>/dev/null)"; then
+      break
+    fi
+    if [[ "$(docker inspect --format '{{.State.Running}}' "${container_name}" 2>/dev/null || true)" != "true" ]]; then
+      echo "Validation container exited before becoming healthy" >&2
+      docker logs "${container_name}" >&2 || true
+      return 1
+    fi
+    sleep 0.25
+  done
+  if [[ "${body}" != *'"status":"healthy"'* || "${body}" != *"\"version\":\"${expected_version}\""* ]]; then
+    echo "Validation container did not return the expected health/version body" >&2
+    docker logs "${container_name}" >&2 || true
+    return 1
+  fi
+
+  cleanup_runtime_validation
+  trap - EXIT HUP INT TERM
+  echo "Runtime image is healthy as UID:GID ${runtime_uid}:${runtime_gid} with revision ${revision_label} and a read-only root filesystem"
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/validate_docker_release.sh package-version
+       scripts/validate_docker_release.sh mode EVENT_NAME GIT_REF
+       scripts/validate_docker_release.sh self-test-release-mode
+       scripts/validate_docker_release.sh provenance [CANDIDATE_REF MAIN_REF]
+       scripts/validate_docker_release.sh self-test-release-provenance
+       scripts/validate_docker_release.sh workflows
+       scripts/validate_docker_release.sh context
+       scripts/validate_docker_release.sh runtime-image IMAGE [EXPECTED_REVISION]
+EOF
+  return 2
+}
+
+command_name="${1:-}"
+case "${command_name}" in
+  package-version)
+    [[ "$#" -eq 1 ]] || usage
+    package_version
+    ;;
+  mode)
+    [[ "$#" -eq 3 ]] || usage
+    release_mode "$2" "$3"
+    ;;
+  self-test-release-mode)
+    [[ "$#" -eq 1 ]] || usage
+    self_test_release_mode
+    ;;
+  provenance)
+    [[ "$#" -le 3 ]] || usage
+    assert_release_provenance "${2:-HEAD}" "${3:-refs/remotes/origin/main}"
+    ;;
+  self-test-release-provenance)
+    [[ "$#" -eq 1 ]] || usage
+    self_test_release_provenance
+    ;;
+  workflows)
+    [[ "$#" -eq 1 ]] || usage
+    validate_workflow_wiring
+    ;;
+  context)
+    [[ "$#" -eq 1 ]] || usage
+    validate_context
+    ;;
+  runtime-image)
+    [[ "$#" -ge 2 && "$#" -le 3 ]] || usage
+    validate_runtime_image "$2" "${3:-}"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/scripts/validate_docker_release.sh
+++ b/scripts/validate_docker_release.sh
@@ -2,7 +2,11 @@
 
 set -euo pipefail
 
+# CDPATH= is an intentional one-command prefix.
+# shellcheck disable=SC1007
 script_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# CDPATH= is an intentional one-command prefix.
+# shellcheck disable=SC1007
 repository_root="$(CDPATH= cd -- "${script_dir}/.." && pwd)"
 docker_context_validation_tmp=""
 docker_runtime_validation_container=""
@@ -379,7 +383,8 @@ validate_runtime_image() {
 
   body=""
   for _attempt in {1..60}; do
-    if body="$(curl --fail --silent --show-error "http://127.0.0.1:${host_port}/health" 2>/dev/null)"; then
+    if body="$(curl --fail --silent --show-error --connect-timeout 2 --max-time 5 \
+      "http://127.0.0.1:${host_port}/health" 2>/dev/null)"; then
       break
     fi
     if [[ "$(docker inspect --format '{{.State.Running}}' "${container_name}" 2>/dev/null || true)" != "true" ]]; then

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,31 @@ impl AppConfig {
 
         config
     }
+
+    /// Host and port passed to the native TCP listener.
+    ///
+    /// Keeping this in the configuration type prevents the startup path from
+    /// silently replacing the operator's `HOST` value with a wildcard bind.
+    pub fn bind_target(&self) -> (&str, u16) {
+        (&self.host, self.port)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppConfig;
+
+    #[test]
+    fn bind_target_uses_the_configured_host_and_port() {
+        let config = AppConfig {
+            port: 43_210,
+            host: "127.0.0.2".to_string(),
+            worker_threads: 1,
+            max_connections: 1,
+        };
+
+        assert_eq!(config.bind_target(), ("127.0.0.2", 43_210));
+    }
 }
 
 /// Gates the optional telemetry exporters.

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ impl Default for AppConfig {
 impl AppConfig {
     pub fn new() -> Self {
         info!("Loading environment configuration");
-        dotenv::dotenv().ok();
+        dotenvy::dotenv().ok();
 
         // Optimize thread count based on CPU cores
         let cpu_count = num_cpus::get();

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2,12 +2,16 @@
 //! resolves the target provider from the `x-provider` header and forwards the
 //! request through [`crate::proxy`].
 
-use crate::{config::AppConfig, proxy::proxy_request_to_provider};
+use crate::{
+    config::AppConfig,
+    landing::{landing_page_html, LANDING_CACHE_CONTROL, LANDING_CONTENT_SECURITY_POLICY},
+    proxy::proxy_request_to_provider,
+};
 use axum::{
     body::Body,
     extract::{ConnectInfo, State},
-    http::{HeaderMap, Request},
-    response::IntoResponse,
+    http::{header, HeaderMap, HeaderName, HeaderValue, Request},
+    response::{Html, IntoResponse, Response},
     Json,
 };
 use serde_json::json;
@@ -18,6 +22,29 @@ use uuid;
 pub async fn health_check() -> impl IntoResponse {
     info!("Health check endpoint called");
     Json(json!({ "status": "healthy", "version": env!("CARGO_PKG_VERSION") }))
+}
+
+/// Serve the dependency-free gateway landing page.
+pub async fn landing_page() -> Response {
+    let mut response = Html(landing_page_html("native-server")).into_response();
+    let headers = response.headers_mut();
+    headers.insert(
+        HeaderName::from_static("content-security-policy"),
+        HeaderValue::from_static(LANDING_CONTENT_SECURITY_POLICY),
+    );
+    headers.insert(
+        HeaderName::from_static("x-content-type-options"),
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        HeaderName::from_static("referrer-policy"),
+        HeaderValue::from_static("no-referrer"),
+    );
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(LANDING_CACHE_CONTROL),
+    );
+    response
 }
 
 pub async fn proxy_request(

--- a/src/landing.rs
+++ b/src/landing.rs
@@ -1,0 +1,146 @@
+//! Shared, dependency-free HTML for the gateway's public root page.
+//!
+//! The native server and Cloudflare Worker serve the same content and security
+//! headers so `/` remains useful without introducing a second web application
+//! or an active-content supply chain.
+
+/// Browser policy for the static landing page.
+///
+/// The page has no JavaScript, images, forms, network requests, or third-party
+/// assets. Its only executable-adjacent content is the inline stylesheet.
+pub const LANDING_CONTENT_SECURITY_POLICY: &str =
+    "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'";
+
+/// Short cache lifetime for an immutable-per-release page while still allowing
+/// a newly deployed version number to become visible quickly.
+pub const LANDING_CACHE_CONTROL: &str = "public, max-age=300";
+
+/// Build the public gateway page for a named runtime.
+///
+/// Callers pass a compile-time runtime label (`native-server` or
+/// `cloudflare-worker`). Escaping it here keeps the helper safe if a future
+/// deployment obtains that label from configuration instead.
+pub fn landing_page_html(runtime: &str) -> String {
+    let runtime = escape_html(runtime);
+    let version = env!("CARGO_PKG_VERSION");
+
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <meta name="description" content="Noveum AI Gateway — one OpenAI-compatible endpoint for multiple AI providers.">
+  <title>Noveum AI Gateway</title>
+  <style>
+    :root {{ color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }}
+    * {{ box-sizing: border-box; }}
+    body {{ margin: 0; min-height: 100vh; color: #eef2ff; background: radial-gradient(circle at 15% 10%, #23346b 0, transparent 34rem), #090d1a; }}
+    main {{ width: min(960px, calc(100% - 32px)); margin: 0 auto; padding: 72px 0 48px; }}
+    .status {{ display: inline-flex; align-items: center; gap: 9px; padding: 7px 11px; border: 1px solid #3d5189; border-radius: 999px; background: #111a35cc; color: #cbd5ff; font-size: 13px; }}
+    .dot {{ width: 8px; height: 8px; border-radius: 50%; background: #50e3a4; box-shadow: 0 0 16px #50e3a4; }}
+    h1 {{ max-width: 720px; margin: 28px 0 14px; font-size: clamp(42px, 8vw, 74px); line-height: .98; letter-spacing: -.055em; }}
+    .lead {{ max-width: 650px; margin: 0; color: #aeb9db; font-size: clamp(17px, 2vw, 21px); line-height: 1.6; }}
+    .grid {{ display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; margin-top: 42px; }}
+    .card {{ min-width: 0; min-height: 174px; padding: 22px; border: 1px solid #26345f; border-radius: 18px; background: linear-gradient(145deg, #111831e6, #0c1124e6); box-shadow: 0 18px 60px #02040c66; }}
+    .card.quick {{ grid-column: 1 / -1; min-height: 0; }}
+    .card h2 {{ margin: 0 0 10px; font-size: 16px; letter-spacing: -.01em; }}
+    .card p {{ margin: 0; color: #9ca9cb; line-height: 1.55; }}
+    code {{ font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: #cdd7ff; }}
+    pre {{ min-width: 0; max-width: 100%; overflow-wrap: anywhere; white-space: pre-wrap; margin: 14px 0 0; padding: 15px; border: 1px solid #27365f; border-radius: 12px; background: #060a15; color: #c9d5ff; font-size: 12px; line-height: 1.55; }}
+    nav {{ display: flex; flex-wrap: wrap; gap: 10px; margin-top: 28px; }}
+    a {{ padding: 10px 14px; border: 1px solid #34477c; border-radius: 10px; color: #d6ddff; text-decoration: none; background: #111a35; }}
+    a:hover, a:focus-visible {{ border-color: #7c95e8; background: #18244b; outline: none; }}
+    footer {{ margin-top: 38px; color: #7380a5; font-size: 13px; }}
+    @media (max-width: 700px) {{
+      main {{ padding-top: 40px; }}
+      .grid {{ grid-template-columns: minmax(0, 1fr); }}
+      .card.quick {{ grid-column: auto; }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <div class="status"><span class="dot" aria-hidden="true"></span>Gateway online</div>
+    <h1>One gateway.<br>Multiple AI providers.</h1>
+    <p class="lead">Noveum AI Gateway provides an OpenAI-compatible request surface with provider routing, streaming, telemetry, and optional Nova Guard enforcement.</p>
+
+    <section class="grid" aria-label="Gateway details">
+      <article class="card">
+        <h2>API endpoint</h2>
+        <p>Send OpenAI-compatible chat requests to <code>/v1/chat/completions</code>. Select the upstream with the <code>x-provider</code> header.</p>
+      </article>
+      <article class="card">
+        <h2>Release</h2>
+        <p>Version <code>{version}</code><br>Runtime <code>{runtime}</code><br>Status <code>/health</code></p>
+      </article>
+      <article class="card quick">
+        <h2>Quick start</h2>
+        <pre>curl "$GATEWAY_URL/v1/chat/completions" \
+  -H "Authorization: Bearer $PROVIDER_API_KEY" \
+  -H "x-provider: openai" \
+  -H "content-type: application/json" \
+  -d '{{"model":"gpt-4o-mini","max_tokens":32,"messages":[{{"role":"user","content":"Hello"}}]}}'</pre>
+      </article>
+    </section>
+
+    <nav aria-label="Project links">
+      <a href="/health">Health</a>
+      <a href="https://docs.rs/noveum-ai-gateway/">Rust documentation</a>
+      <a href="https://github.com/Noveum/ai-gateway">Source and guides</a>
+      <a href="https://noveum.ai">Noveum</a>
+    </nav>
+    <footer>Noveum AI Gateway · API responses are served under <code>/v1/*</code>.</footer>
+  </main>
+</body>
+</html>"#
+    )
+}
+
+fn escape_html(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{landing_page_html, LANDING_CONTENT_SECURITY_POLICY};
+
+    #[test]
+    fn landing_page_identifies_the_release_and_stable_gateway_routes() {
+        let html = landing_page_html("cloudflare-worker");
+
+        assert!(html.starts_with("<!doctype html>"));
+        assert!(html.contains(env!("CARGO_PKG_VERSION")));
+        assert!(html.contains("cloudflare-worker"));
+        assert!(html.contains("/health"));
+        assert!(html.contains("/v1/chat/completions"));
+        assert!(html.contains("https://docs.rs/noveum-ai-gateway/"));
+        assert!(html.contains("https://github.com/Noveum/ai-gateway"));
+        assert!(html.contains("\"model\":\"gpt-4o-mini\""));
+        assert!(html.contains("\"max_tokens\":32"));
+        assert!(!html.contains("<script"));
+        assert!(!html.contains("<form"));
+    }
+
+    #[test]
+    fn landing_page_escapes_the_runtime_label() {
+        let html = landing_page_html("edge<script>alert(1)</script>");
+
+        assert!(html.contains("edge&lt;script&gt;alert(1)&lt;/script&gt;"));
+        assert!(!html.contains("edge<script>"));
+    }
+
+    #[test]
+    fn landing_page_security_policy_disallows_active_or_embedded_content() {
+        assert_eq!(
+            LANDING_CONTENT_SECURITY_POLICY,
+            "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 // Shared core: compiles to BOTH the native server and the wasm32 Cloudflare
 // Worker, so guardrails + request routing behave identically on every deployment
 // shape.
+pub mod landing;
 pub mod policy;
 pub mod routing;
 pub mod sigv4;
@@ -156,6 +157,7 @@ pub fn build_router(state: AppState) -> Router {
         .max_age(std::time::Duration::from_secs(3600));
 
     let mut router = Router::new()
+        .route("/", get(handlers::landing_page))
         .route("/health", get(handlers::health_check))
         .route("/v1/*path", any(handlers::proxy_request))
         // Nova Guard policy enforcement runs closest to the handler so it sees the
@@ -189,4 +191,98 @@ pub fn build_router(state: AppState) -> Router {
         ))
         .with_state(state.config.clone())
         .layer(cors)
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::{build_router, AppState};
+    use crate::{
+        config::AppConfig,
+        landing::LANDING_CONTENT_SECURITY_POLICY,
+        policy::{engine::EngineOptions, PolicyBundle, PolicyEngine},
+        telemetry::MetricsRegistry,
+    };
+    use axum::{
+        body::Body,
+        http::{header, Method, Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn root_route_serves_the_secure_landing_page() {
+        let policy = PolicyEngine::from_bundle(&PolicyBundle::default(), EngineOptions::default());
+        let state = AppState::new(
+            Arc::new(AppConfig::default()),
+            Arc::new(MetricsRegistry::new(false)),
+            Arc::new(policy),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let app = build_router(state);
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/html; charset=utf-8"
+        );
+        assert_eq!(
+            response.headers().get("content-security-policy").unwrap(),
+            LANDING_CONTENT_SECURITY_POLICY
+        );
+        assert_eq!(
+            response.headers().get("x-content-type-options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(
+            response.headers().get("referrer-policy").unwrap(),
+            "no-referrer"
+        );
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            "public, max-age=300"
+        );
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let html = std::str::from_utf8(&body).unwrap();
+        assert!(html.contains("native-server"));
+        assert!(html.contains(env!("CARGO_PKG_VERSION")));
+
+        let head = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::HEAD)
+                    .uri("/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(head.status(), StatusCode::OK);
+        for name in [
+            header::CONTENT_TYPE.as_str(),
+            "content-security-policy",
+            "x-content-type-options",
+            "referrer-policy",
+            header::CACHE_CONTROL.as_str(),
+        ] {
+            assert!(head.headers().contains_key(name), "missing {name}");
+        }
+        assert!(head
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .is_empty());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,10 @@ use noveum_ai_gateway::{
     AppState,
 };
 
-#[tokio::main]
-async fn main() {
-    print_banner().await;
-
-    // Initialize tracing
-    info!("Initializing tracing system");
+fn main() {
+    // Load `.env` before tracing so `RUST_LOG` and the runtime settings are
+    // available before Tokio creates any worker threads.
+    dotenv::dotenv().ok();
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::new(
             std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()),
@@ -35,7 +33,6 @@ async fn main() {
         .with(tracing_subscriber::fmt::layer().compact())
         .init();
 
-    // Load configuration
     info!("Loading application configuration");
     let config = Arc::new(AppConfig::new());
     debug!(
@@ -43,13 +40,34 @@ async fn main() {
         config.port, config.host, config.worker_threads
     );
 
-    // Optimize tokio runtime
+    let runtime = build_runtime(config.worker_threads).unwrap_or_else(|error| {
+        eprintln!("Failed to build Tokio runtime: {error}");
+        std::process::exit(1);
+    });
+    runtime.block_on(run(config));
+}
+
+fn build_runtime(worker_threads: usize) -> std::io::Result<tokio::runtime::Runtime> {
+    if worker_threads == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "WORKER_THREADS must be greater than zero",
+        ));
+    }
+
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(worker_threads)
+        .thread_stack_size(2 * 1024 * 1024)
+        .enable_all()
+        .build()
+}
+
+async fn run(config: Arc<AppConfig>) {
+    print_banner().await;
     info!(
-        "Configuring tokio runtime with {} worker threads",
+        "Tokio runtime started with {} worker threads",
         config.worker_threads
     );
-    std::env::set_var("TOKIO_WORKER_THREADS", config.worker_threads.to_string());
-    std::env::set_var("TOKIO_THREAD_STACK_SIZE", (2 * 1024 * 1024).to_string());
 
     // Telemetry registry + exporters
     let telemetry_config = TelemetryConfig::default();
@@ -292,9 +310,9 @@ async fn main() {
     let app = build_router(state);
 
     // Start server with optimized TCP settings
-    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], config.port));
     info!("Setting up TCP listener with non-blocking mode");
-    let tcp_listener = std::net::TcpListener::bind(addr).expect("Failed to bind address");
+    let tcp_listener = std::net::TcpListener::bind(config.bind_target())
+        .expect("Failed to bind configured HOST and PORT");
     tcp_listener
         .set_nonblocking(true)
         .expect("Failed to set non-blocking");
@@ -448,5 +466,14 @@ async fn shutdown_signal() {
             println!("{}", "    🛑 Noveum AI Gateway shutting down...".bright_yellow());
             info!("SIGTERM received, starting graceful shutdown");
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn runtime_uses_the_configured_worker_thread_count() {
+        let runtime = super::build_runtime(3).expect("test runtime should build");
+        assert_eq!(runtime.metrics().num_workers(), 3);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use noveum_ai_gateway::{
 fn main() {
     // Load `.env` before tracing so `RUST_LOG` and the runtime settings are
     // available before Tokio creates any worker threads.
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::new(
             std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()),

--- a/src/policy/middleware.rs
+++ b/src/policy/middleware.rs
@@ -329,6 +329,22 @@ pub async fn guard_middleware(
             )
             .into_response();
         }
+        let region = match parts.headers.get("x-aws-region") {
+            Some(value) => match value.to_str() {
+                Ok(region) => region,
+                Err(_) => {
+                    return crate::error::AppError::RequestError(
+                        "x-aws-region must be a valid UTF-8 AWS region such as us-east-1"
+                            .to_string(),
+                    )
+                    .into_response();
+                }
+            },
+            None => crate::routing::BEDROCK_DEFAULT_REGION,
+        };
+        if let Err(message) = crate::routing::validate_aws_region(region) {
+            return crate::error::AppError::RequestError(message).into_response();
+        }
     } else if engine.stateful_policy_count() > 0 {
         let bearer = parts
             .headers
@@ -1540,8 +1556,8 @@ impl SharedTenancy {
 
 /// Does this path require an authenticated tenant? **Pure.**
 ///
-/// Only the proxy surface. `/health` stays reachable so liveness/readiness
-/// probes do not need a tenant credential.
+/// Only the proxy surface. `/` and `/health` stay reachable so visitors and
+/// liveness/readiness probes do not need a tenant credential.
 pub fn requires_tenant(path: &str) -> bool {
     path.starts_with("/v1/")
 }

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -12,7 +12,8 @@ use crate::error::AppError;
 use crate::routing::{validate_aws_region, BEDROCK_DEFAULT_REGION};
 use crate::telemetry::provider_metrics::{MetricsExtractor, ProviderMetrics};
 use async_trait::async_trait;
-use aws_event_stream_parser::{parse_message, Message};
+use aws_smithy_eventstream::frame::read_message_from;
+use aws_smithy_types::event_stream::Message;
 use axum::{
     body::{Body, Bytes},
     http::{HeaderMap, Response, StatusCode},
@@ -21,7 +22,7 @@ use futures_util::StreamExt;
 use parking_lot::RwLock;
 use serde_json::{json, Value};
 use std::sync::Arc;
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 use uuid;
 
 /// Constants for default values
@@ -96,28 +97,17 @@ impl BedrockProvider {
 
     fn transform_bedrock_chunk(&self, chunk: Bytes) -> Result<Bytes, AppError> {
         debug!("Processing chunk of size: {}", chunk.len());
-        let mut remaining = chunk.as_ref();
-        let mut response_events = Vec::new();
-
-        while !remaining.is_empty() {
-            match self.process_message(remaining) {
-                Ok((rest, events)) => {
-                    remaining = rest;
-                    response_events.extend(events);
-                }
-                Err(e) => {
-                    debug!("Failed to parse message: {:?}", e);
-                    break;
-                }
-            }
-        }
-
+        let response_events = self.process_message(chunk.as_ref())?;
         Ok(Bytes::from(response_events.join("")))
     }
 
-    fn process_message<'a>(&self, data: &'a [u8]) -> Result<(&'a [u8], Vec<String>), AppError> {
-        let (rest, message) =
-            parse_message(data).map_err(|e| AppError::EventStreamError(e.to_string()))?;
+    fn process_message(&self, data: &[u8]) -> Result<Vec<String>, AppError> {
+        // `process_response` splits the buffered transport stream at the
+        // prelude's total-length boundary, so this slice contains exactly one
+        // complete AWS EventStream frame. The Smithy reader validates both the
+        // prelude CRC and the message CRC before exposing headers or payload.
+        let message =
+            read_message_from(data).map_err(|e| AppError::EventStreamError(e.to_string()))?;
 
         let event_type = self.get_event_type(&message);
         let events = match event_type.as_deref() {
@@ -129,23 +119,16 @@ impl BedrockProvider {
             }
         };
 
-        if !message.valid() {
-            warn!("Invalid message checksum detected");
-        }
-
-        Ok((rest, events))
+        Ok(events)
     }
 
     fn get_event_type(&self, message: &Message) -> Option<String> {
         message
-            .headers
-            .headers
+            .headers()
             .iter()
-            .find(|h| h.key == ":event-type")
-            .and_then(|h| match &h.value {
-                aws_event_stream_parser::HeaderValue::String(s) => Some(s.to_string()),
-                _ => None,
-            })
+            .find(|header| header.name().as_str() == ":event-type")
+            .and_then(|header| header.value().as_string().ok())
+            .map(|value| value.as_str().to_string())
     }
 
     /// Handles content block chunks from Bedrock and transforms them to the OpenAI streaming format.
@@ -154,7 +137,7 @@ impl BedrockProvider {
     /// For all chunks, this includes the same system_fingerprint and required OpenAI fields
     /// for compatibility with OpenAI SDKs.
     fn handle_content_block(&self, message: &Message) -> Result<Vec<String>, AppError> {
-        let body_str = String::from_utf8(message.body.to_vec())?;
+        let body_str = String::from_utf8(message.payload().to_vec())?;
         let json: Value = serde_json::from_str(&body_str)?;
 
         if let Some(delta) = json
@@ -175,7 +158,7 @@ impl BedrockProvider {
     /// The final chunk includes usage information and a finish_reason of "stop".
     /// This also includes the [DONE] marker required by OpenAI's streaming protocol.
     fn handle_metadata(&self, message: &Message) -> Result<Vec<String>, AppError> {
-        let body_str = String::from_utf8(message.body.to_vec())?;
+        let body_str = String::from_utf8(message.payload().to_vec())?;
         let json: Value = serde_json::from_str(&body_str)?;
 
         if let Some(usage) = json.get("usage") {
@@ -812,17 +795,17 @@ mod tests {
 
     #[tokio::test]
     async fn native_event_stream_reassembles_transport_fragmented_messages() {
-        use aws_event_stream_parser::{Header, HeaderBlock};
+        use aws_smithy_eventstream::frame::write_message_to;
+        use aws_smithy_types::event_stream::{Header, HeaderValue};
 
         fn event(kind: &str, body: Value) -> Vec<u8> {
-            Message::build(
-                HeaderBlock {
-                    headers: vec![Header::from_pair(":event-type", kind)],
-                },
-                serde_json::to_vec(&body).unwrap(),
-            )
-            .as_buffer()
-            .to_vec()
+            let message = Message::new(serde_json::to_vec(&body).unwrap()).add_header(Header::new(
+                ":event-type",
+                HeaderValue::String(kind.to_string().into()),
+            ));
+            let mut buffer = Vec::new();
+            write_message_to(&message, &mut buffer).unwrap();
+            buffer
         }
 
         let provider = BedrockProvider::new();
@@ -861,6 +844,68 @@ mod tests {
             .expect("the terminal metadata frame must settle the reservation");
         assert_eq!(usage.input_tokens, 7);
         assert_eq!(usage.output_tokens, 2);
+    }
+
+    #[tokio::test]
+    async fn native_event_stream_rejects_a_corrupt_message_checksum() {
+        use aws_smithy_eventstream::frame::write_message_to;
+        use aws_smithy_types::event_stream::{Header, HeaderValue};
+
+        let message =
+            Message::new(serde_json::to_vec(&json!({"delta": {"text": "must-not-pass"}})).unwrap())
+                .add_header(Header::new(
+                    ":event-type",
+                    HeaderValue::String("contentBlockDelta".into()),
+                ));
+        let mut wire = Vec::new();
+        write_message_to(&message, &mut wire).unwrap();
+        *wire.last_mut().expect("message checksum") ^= 0x01;
+
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", "application/vnd.amazon.eventstream")
+            .body(Body::from(wire))
+            .unwrap();
+
+        let transformed = BedrockProvider::new()
+            .process_response(response)
+            .await
+            .unwrap();
+        axum::body::to_bytes(transformed.into_body(), usize::MAX)
+            .await
+            .expect_err("a corrupt AWS EventStream checksum must fail the downstream body");
+    }
+
+    #[tokio::test]
+    async fn native_event_stream_rejects_a_corrupt_prelude_checksum() {
+        use aws_smithy_eventstream::frame::write_message_to;
+        use aws_smithy_types::event_stream::{Header, HeaderValue};
+
+        let message =
+            Message::new(serde_json::to_vec(&json!({"delta": {"text": "must-not-pass"}})).unwrap())
+                .add_header(Header::new(
+                    ":event-type",
+                    HeaderValue::String("contentBlockDelta".into()),
+                ));
+        let mut wire = Vec::new();
+        write_message_to(&message, &mut wire).unwrap();
+        // Bytes 8..12 are the prelude CRC. Keep total_len intact so the outer
+        // frame splitter reaches the Smithy checksum validation path.
+        wire[11] ^= 0x01;
+
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", "application/vnd.amazon.eventstream")
+            .body(Body::from(wire))
+            .unwrap();
+
+        let transformed = BedrockProvider::new()
+            .process_response(response)
+            .await
+            .unwrap();
+        axum::body::to_bytes(transformed.into_body(), usize::MAX)
+            .await
+            .expect_err("a corrupt AWS EventStream prelude checksum must fail the downstream body");
     }
 
     #[test]

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -9,6 +9,7 @@
 use super::utils::log_tracking_headers;
 use super::Provider;
 use crate::error::AppError;
+use crate::routing::{validate_aws_region, BEDROCK_DEFAULT_REGION};
 use crate::telemetry::provider_metrics::{MetricsExtractor, ProviderMetrics};
 use async_trait::async_trait;
 use aws_event_stream_parser::{parse_message, Message};
@@ -24,7 +25,6 @@ use tracing::{debug, error, warn};
 use uuid;
 
 /// Constants for default values
-const DEFAULT_REGION: &str = "us-east-1";
 const DEFAULT_MODEL: &str = "amazon.titan-text-premier-v1:0";
 const MAX_EVENT_STREAM_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
 
@@ -47,7 +47,7 @@ impl Default for BedrockProvider {
 
 impl BedrockProvider {
     pub fn new() -> Self {
-        let region = DEFAULT_REGION.to_string();
+        let region = BEDROCK_DEFAULT_REGION.to_string();
         debug!("Initializing BedrockProvider with region: {}", region);
 
         // Create a random system fingerprint that will be reused across chunks
@@ -329,7 +329,13 @@ impl Provider for BedrockProvider {
         }
 
         // Extract and set the region from the request headers
-        if let Some(region) = headers.get("x-aws-region").and_then(|h| h.to_str().ok()) {
+        if let Some(region) = headers.get("x-aws-region") {
+            let region = region.to_str().map_err(|_| {
+                AppError::RequestError(
+                    "x-aws-region must be a valid UTF-8 AWS region such as us-east-1".to_string(),
+                )
+            })?;
+            validate_aws_region(region).map_err(AppError::RequestError)?;
             debug!("Setting region from before_request: {}", region);
             *self.region.write() = region.to_string();
             *self.base_url.write() = format!("https://bedrock-runtime.{}.amazonaws.com", region);
@@ -396,13 +402,21 @@ impl Provider for BedrockProvider {
     }
 
     fn get_signing_credentials(&self, headers: &HeaderMap) -> Option<(String, String, String)> {
-        let access_key = headers.get("x-aws-access-key-id")?.to_str().ok()?;
-        let secret_key = headers.get("x-aws-secret-access-key")?.to_str().ok()?;
+        let access_key = headers.get("x-aws-access-key-id")?.to_str().ok()?.trim();
+        let secret_key = headers
+            .get("x-aws-secret-access-key")?
+            .to_str()
+            .ok()?
+            .trim();
+        if access_key.is_empty() || secret_key.is_empty() {
+            return None;
+        }
         let region = headers
             .get("x-aws-region")
             .and_then(|h| h.to_str().ok())
             .map(String::from)
             .unwrap_or_else(|| self.region.read().clone());
+        validate_aws_region(&region).ok()?;
 
         Some((access_key.to_string(), secret_key.to_string(), region))
     }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -18,10 +18,17 @@ mod signing;
 pub async fn proxy_request_to_provider(
     config: Arc<AppConfig>,
     provider_name: &str,
-    mut original_request: Request<Body>,
+    original_request: Request<Body>,
 ) -> Result<Response<Body>, AppError> {
     let provider = create_provider(provider_name)?;
+    proxy_request_with_provider(config, provider, original_request).await
+}
 
+async fn proxy_request_with_provider(
+    config: Arc<AppConfig>,
+    provider: Box<dyn Provider>,
+    mut original_request: Request<Body>,
+) -> Result<Response<Body>, AppError> {
     // Extract body bytes
     let body = std::mem::replace(original_request.body_mut(), Body::empty());
     let body_bytes = to_bytes(body, usize::MAX)
@@ -52,20 +59,23 @@ pub async fn proxy_request_to_provider(
 
     // Handle AWS signing if required
     let final_headers = if provider.requires_signing() {
-        if let Some((access_key, secret_key, region)) = provider.get_signing_credentials(&headers) {
-            signing::sign_aws_request(
-                original_request.method().as_str(),
-                &url,
-                &prepared_body,
-                &access_key,
-                &secret_key,
-                &region,
-                "bedrock",
-            )
-            .await?
-        } else {
-            headers
-        }
+        let (access_key, secret_key, region) = provider
+            .get_signing_credentials(&headers)
+            .ok_or(AppError::MissingApiKey)?;
+        let session_token = headers
+            .get("x-aws-session-token")
+            .and_then(|value| value.to_str().ok());
+        signing::sign_aws_request(
+            original_request.method().as_str(),
+            &url,
+            &prepared_body,
+            &access_key,
+            &secret_key,
+            session_token,
+            &region,
+            "bedrock",
+        )
+        .await?
     } else {
         headers
     };
@@ -184,6 +194,204 @@ async fn process_response(
     }
 
     Ok(response_builder.body(Body::from_stream(stream)).unwrap())
+}
+
+#[cfg(test)]
+mod credential_tests {
+    use super::proxy_request_with_provider;
+    use crate::{
+        config::AppConfig,
+        error::AppError,
+        providers::{BedrockProvider, Provider},
+    };
+    use async_trait::async_trait;
+    use axum::{
+        body::Body,
+        http::{HeaderMap, HeaderValue, Request, Response},
+    };
+    use std::{sync::Arc, time::Duration};
+    use tokio::{net::TcpListener, time::timeout};
+
+    struct LoopbackSigningProvider {
+        base_url: String,
+        credential_parser: BedrockProvider,
+    }
+
+    #[async_trait]
+    impl Provider for LoopbackSigningProvider {
+        fn base_url(&self) -> String {
+            self.base_url.clone()
+        }
+
+        fn name(&self) -> &str {
+            "loopback-signing-test"
+        }
+
+        fn process_headers(&self, headers: &HeaderMap) -> Result<HeaderMap, AppError> {
+            Ok(headers.clone())
+        }
+
+        fn requires_signing(&self) -> bool {
+            true
+        }
+
+        fn get_signing_credentials(&self, headers: &HeaderMap) -> Option<(String, String, String)> {
+            self.credential_parser.get_signing_credentials(headers)
+        }
+
+        async fn process_response(
+            &self,
+            response: Response<Body>,
+        ) -> Result<Response<Body>, AppError> {
+            Ok(response)
+        }
+    }
+
+    async fn assert_bedrock_credentials_fail_without_dispatch(
+        access_key: Option<HeaderValue>,
+        secret_key: Option<HeaderValue>,
+    ) {
+        // Route any erroneous fallback into a controlled loopback listener. A
+        // correct credential failure returns before the HTTP client can connect.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let dispatch_probe = tokio::spawn(async move {
+            timeout(Duration::from_millis(250), listener.accept())
+                .await
+                .is_ok()
+        });
+
+        let mut request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .header("x-aws-region", "us-east-1")
+            .body(Body::from(
+                r#"{"model":"amazon.nova-micro-v1:0","messages":[{"role":"user","content":"hello"}],"max_tokens":1}"#,
+            ))
+            .unwrap();
+        if let Some(value) = access_key {
+            request.headers_mut().insert("x-aws-access-key-id", value);
+        }
+        if let Some(value) = secret_key {
+            request
+                .headers_mut()
+                .insert("x-aws-secret-access-key", value);
+        }
+
+        let result = timeout(
+            Duration::from_secs(2),
+            proxy_request_with_provider(
+                Arc::new(AppConfig {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    worker_threads: 1,
+                    max_connections: 1,
+                }),
+                Box::new(LoopbackSigningProvider {
+                    base_url: format!("https://127.0.0.1:{port}"),
+                    credential_parser: BedrockProvider::new(),
+                }),
+                request,
+            ),
+        )
+        .await
+        .expect("credential validation must finish locally");
+        let dispatched = dispatch_probe.await.unwrap();
+
+        match result {
+            Err(AppError::MissingApiKey) => {}
+            Err(error) => panic!("expected a credential error, got {error}"),
+            Ok(_) => panic!("missing Bedrock credentials were accepted"),
+        }
+        assert!(!dispatched, "credential failure reached the network client");
+    }
+
+    #[tokio::test]
+    async fn missing_bedrock_access_or_secret_fails_before_network_dispatch() {
+        let valid_access = HeaderValue::from_static("AKIDEXAMPLE");
+        let valid_secret = HeaderValue::from_static("secret-example");
+
+        assert_bedrock_credentials_fail_without_dispatch(None, Some(valid_secret.clone())).await;
+        assert_bedrock_credentials_fail_without_dispatch(Some(valid_access), None).await;
+    }
+
+    #[tokio::test]
+    async fn malformed_bedrock_access_or_secret_fails_before_network_dispatch() {
+        let valid_access = HeaderValue::from_static("AKIDEXAMPLE");
+        let valid_secret = HeaderValue::from_static("secret-example");
+        let malformed = [
+            HeaderValue::from_static(""),
+            HeaderValue::from_static("   "),
+            HeaderValue::from_bytes(&[0x80]).unwrap(),
+        ];
+
+        for value in malformed.iter().cloned() {
+            assert_bedrock_credentials_fail_without_dispatch(
+                Some(value),
+                Some(valid_secret.clone()),
+            )
+            .await;
+        }
+        for value in malformed {
+            assert_bedrock_credentials_fail_without_dispatch(
+                Some(valid_access.clone()),
+                Some(value),
+            )
+            .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn authority_shaped_bedrock_region_fails_before_network_dispatch() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let dispatch_probe = tokio::spawn(async move {
+            timeout(Duration::from_millis(250), listener.accept())
+                .await
+                .is_ok()
+        });
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .header("x-aws-access-key-id", "AKIDEXAMPLE")
+            .header("x-aws-secret-access-key", "secret-example")
+            .header(
+                "x-aws-region",
+                format!("us-east-1.amazonaws.com@127.0.0.1:{port}"),
+            )
+            .body(Body::from(
+                r#"{"model":"amazon.nova-micro-v1:0","messages":[{"role":"user","content":"hello"}],"max_tokens":1}"#,
+            ))
+            .unwrap();
+
+        let result = timeout(
+            Duration::from_secs(2),
+            proxy_request_with_provider(
+                Arc::new(AppConfig {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    worker_threads: 1,
+                    max_connections: 1,
+                }),
+                Box::new(BedrockProvider::new()),
+                request,
+            ),
+        )
+        .await
+        .expect("region validation must finish locally");
+        let dispatched = dispatch_probe.await.unwrap();
+
+        match result {
+            Err(AppError::RequestError(message)) => {
+                assert!(message.contains("x-aws-region"), "{message}");
+            }
+            Err(error) => panic!("expected a region validation error, got {error}"),
+            Ok(_) => panic!("authority-shaped Bedrock region was accepted"),
+        }
+        assert!(!dispatched, "invalid region reached the network client");
+    }
 }
 
 #[cfg(test)]

--- a/src/proxy/signing.rs
+++ b/src/proxy/signing.rs
@@ -12,14 +12,21 @@ pub async fn sign_aws_request(
     body: &[u8],
     access_key: &str,
     secret_key: &str,
+    session_token: Option<&str>,
     region: &str,
     service: &str,
 ) -> Result<HeaderMap, AppError> {
     debug!("Signing request with method: {}, url: {}", method, url);
 
     // Create credentials
-    let identity =
-        Credentials::new(access_key, secret_key, None, None, "signing-credentials").into();
+    let identity = Credentials::new(
+        access_key,
+        secret_key,
+        session_token.map(str::to_owned),
+        None,
+        "signing-credentials",
+    )
+    .into();
 
     // Create signing parameters
     let signing_settings = SigningSettings::default();
@@ -65,6 +72,47 @@ pub async fn sign_aws_request(
         final_headers.insert(key.clone(), value.clone());
     }
 
-    debug!("Final signed headers: {:?}", final_headers);
+    // Never log signed header values: `authorization` is credential-derived and
+    // temporary credentials add the raw `x-amz-security-token` value.
+    debug!("AWS request signed with {} headers", final_headers.len());
     Ok(final_headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sign_aws_request;
+
+    #[tokio::test]
+    async fn temporary_credentials_sign_and_forward_the_security_token() {
+        let headers = sign_aws_request(
+            "POST",
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.nova-micro-v1:0/converse",
+            br#"{"inputText":"hello"}"#,
+            "AKID",
+            "secret",
+            Some("session-token-123"),
+            "us-east-1",
+            "bedrock",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            headers
+                .get("x-amz-security-token")
+                .and_then(|value| value.to_str().ok()),
+            Some("session-token-123")
+        );
+        assert!(headers.contains_key("authorization"));
+        for raw_header in [
+            "x-aws-access-key-id",
+            "x-aws-secret-access-key",
+            "x-aws-session-token",
+        ] {
+            assert!(
+                !headers.contains_key(raw_header),
+                "raw caller credential header leaked into the signed request: {raw_header}"
+            );
+        }
+    }
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1974,11 +1974,16 @@ pub fn openai_to_anthropic_messages_with_assumed_output_tokens(
 /// `stream: true` there would silently violate the caller's transport contract.
 /// Keep this check shared and target-independent so its behavior is unit tested.
 pub fn validate_worker_bedrock_request(body: &Value) -> Result<(), String> {
-    if body.get("stream").and_then(Value::as_bool) == Some(true) {
-        return Err(
-            "Bedrock streaming is not supported by the Cloudflare Worker; use the native gateway for ConverseStream or omit stream for buffered Converse"
-                .to_string(),
-        );
+    if let Some(stream) = body.get("stream") {
+        let stream = stream
+            .as_bool()
+            .ok_or_else(|| "Bedrock stream must be a Boolean when present".to_string())?;
+        if stream {
+            return Err(
+                "Bedrock streaming is not supported by the Cloudflare Worker; use the native gateway for ConverseStream or omit stream for buffered Converse"
+                    .to_string(),
+            );
+        }
     }
     Ok(())
 }
@@ -4102,6 +4107,12 @@ mod tests {
         });
         assert!(validate_worker_bedrock_request(&buffered).is_ok());
 
+        let omitted = json!({
+            "model": "amazon.nova-micro-v1:0",
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+        assert!(validate_worker_bedrock_request(&omitted).is_ok());
+
         let streaming = json!({
             "model": "amazon.nova-micro-v1:0",
             "stream": true,
@@ -4110,6 +4121,17 @@ mod tests {
         let error = validate_worker_bedrock_request(&streaming).unwrap_err();
         assert!(error.contains("Cloudflare Worker"), "{error}");
         assert!(error.contains("stream"), "{error}");
+
+        for invalid_stream in [json!("true"), json!(1), json!(null), json!({})] {
+            let invalid = json!({
+                "model": "amazon.nova-micro-v1:0",
+                "stream": invalid_stream,
+                "messages": [{"role": "user", "content": "hello"}]
+            });
+            let error = validate_worker_bedrock_request(&invalid)
+                .expect_err("a present non-Boolean stream field must be rejected");
+            assert!(error.contains("Boolean"), "{error}");
+        }
     }
 
     #[test]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -14,6 +14,47 @@ pub const OPENAI_BASE_URL_VAR: &str = "OPENAI_BASE_URL";
 /// Base-URL override for Anthropic's native Messages API. Used by both runtimes
 /// for hermetic transport tests and private compatible endpoints.
 pub const ANTHROPIC_BASE_URL_VAR: &str = "ANTHROPIC_BASE_URL";
+/// Default AWS region used by the Bedrock adapters when the caller omits
+/// `x-aws-region`.
+pub const BEDROCK_DEFAULT_REGION: &str = "us-east-1";
+
+const MAX_AWS_REGION_LEN: usize = 32;
+
+/// Validate an AWS region before it is interpolated into a Bedrock authority.
+///
+/// A region is caller-controlled on this gateway. Restricting it to the
+/// conservative AWS region grammar keeps the resulting host below
+/// `amazonaws.com` and rejects URL delimiters such as `.`, `/`, `@`, `:`, `?`,
+/// and `#` before either runtime constructs or dispatches a request.
+pub fn validate_aws_region(region: &str) -> Result<(), String> {
+    let invalid = || {
+        "x-aws-region must be a valid AWS region such as us-east-1 (ASCII lowercase letters, digits, and hyphens; maximum 32 characters)"
+            .to_string()
+    };
+
+    if region.is_empty()
+        || region.len() > MAX_AWS_REGION_LEN
+        || !region
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err(invalid());
+    }
+
+    let mut segments = region.split('-').collect::<Vec<_>>();
+    let Some(ordinal) = segments.pop() else {
+        return Err(invalid());
+    };
+    if segments.len() < 2
+        || segments.iter().any(|segment| segment.is_empty())
+        || ordinal.is_empty()
+        || !ordinal.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(invalid());
+    }
+
+    Ok(())
+}
 
 /// Where an OpenAI-compatible request should be forwarded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -128,6 +169,18 @@ pub fn authorization_bearer_token(value: &str) -> Option<&str> {
         return None;
     }
     Some(token)
+}
+
+/// Whether a header carries credentials for a provider other than the generic
+/// Bearer-auth path.
+///
+/// These headers must never ride generic header pass-through: the selected
+/// Anthropic or Bedrock adapter re-adds only the credentials it actually uses.
+pub fn is_cross_provider_credential_header(name: &str) -> bool {
+    name.eq_ignore_ascii_case("x-api-key")
+        || name
+            .get(..6)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("x-aws-"))
 }
 
 /// [`upstream_url`], with an optional base that replaces the route's own.
@@ -1914,6 +1967,22 @@ pub fn openai_to_anthropic_messages_with_assumed_output_tokens(
     Ok(body)
 }
 
+/// Validate the Bedrock surface currently implemented by the Cloudflare Worker.
+///
+/// Native uses an incremental AWS EventStream decoder for `ConverseStream`.
+/// The Worker currently implements buffered `Converse` only, so accepting
+/// `stream: true` there would silently violate the caller's transport contract.
+/// Keep this check shared and target-independent so its behavior is unit tested.
+pub fn validate_worker_bedrock_request(body: &Value) -> Result<(), String> {
+    if body.get("stream").and_then(Value::as_bool) == Some(true) {
+        return Err(
+            "Bedrock streaming is not supported by the Cloudflare Worker; use the native gateway for ConverseStream or omit stream for buffered Converse"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Convert an OpenAI chat-completions body into the AWS Bedrock **Converse** API
 /// request shape. Mirrors the native `BedrockProvider::transform_request_body`
 /// (defaults: maxTokens 1000, temperature 0.7, topP 1.0).
@@ -2059,6 +2128,53 @@ mod tests {
             ("", None),
         ] {
             assert_eq!(authorization_bearer_token(raw), expected, "{raw:?}");
+        }
+    }
+
+    #[test]
+    fn aws_region_validation_accepts_commercial_and_partition_regions() {
+        for region in [
+            "us-east-1",
+            "us-west-2",
+            "eu-west-1",
+            "ap-south-1",
+            "ap-southeast-2",
+            "ca-central-1",
+            "me-south-1",
+            "af-south-1",
+            "il-central-1",
+            "mx-central-1",
+            "cn-north-1",
+            "us-gov-west-1",
+        ] {
+            assert!(validate_aws_region(region).is_ok(), "{region}");
+        }
+    }
+
+    #[test]
+    fn aws_region_validation_rejects_empty_delimited_or_overlong_values() {
+        for region in [
+            "",
+            " ",
+            " us-east-1",
+            "us-east-1 ",
+            "US-EAST-1",
+            "us-east",
+            "us-east-one",
+            "us--east-1",
+            "-us-east-1",
+            "us-east-1-",
+            "us_east_1",
+            "us-east-1.evil.invalid",
+            "us-east-1/evil",
+            "us-east-1@evil.invalid",
+            "us-east-1:443",
+            "us-east-1?query",
+            "us-east-1#fragment",
+            "commercial-super-long-region-name-1",
+        ] {
+            let error = validate_aws_region(region).expect_err(region);
+            assert!(error.contains("x-aws-region"), "{region:?}: {error}");
         }
     }
 
@@ -3978,6 +4094,25 @@ mod tests {
     }
 
     #[test]
+    fn worker_bedrock_preflight_rejects_streaming_until_eventstream_is_supported() {
+        let buffered = json!({
+            "model": "amazon.nova-micro-v1:0",
+            "stream": false,
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+        assert!(validate_worker_bedrock_request(&buffered).is_ok());
+
+        let streaming = json!({
+            "model": "amazon.nova-micro-v1:0",
+            "stream": true,
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+        let error = validate_worker_bedrock_request(&streaming).unwrap_err();
+        assert!(error.contains("Cloudflare Worker"), "{error}");
+        assert!(error.contains("stream"), "{error}");
+    }
+
+    #[test]
     fn bedrock_converse_to_openai_maps_content_usage_and_finish() {
         let resp = json!({
             "output": {"message": {"content": [{"text": "hi there"}]}},
@@ -4072,5 +4207,22 @@ mod tests {
         assert_eq!(out["choices"][0]["message"]["content"], "abc");
         // safety stop surfaced distinctly.
         assert_eq!(out["choices"][0]["finish_reason"], "content_filter");
+    }
+
+    #[test]
+    fn cross_provider_credentials_are_never_copied_as_generic_headers() {
+        for name in [
+            "x-api-key",
+            "X-API-Key",
+            "x-aws-access-key-id",
+            "x-aws-secret-access-key",
+            "x-aws-session-token",
+            "x-aws-region",
+        ] {
+            assert!(is_cross_provider_credential_header(name), "{name}");
+        }
+        for name in ["authorization", "anthropic-beta", "x-request-id"] {
+            assert!(!is_cross_provider_credential_header(name), "{name}");
+        }
     }
 }

--- a/src/sigv4.rs
+++ b/src/sigv4.rs
@@ -8,7 +8,7 @@
 //! Crypto `SubtleCrypto` API. The module is compiled on both targets so the
 //! algorithm is unit-tested in native CI.
 //!
-//! Unlike the native path, this supports **temporary credentials**: an
+//! Like the native path, this supports **temporary credentials**: an
 //! `x-amz-security-token` is signed + sent when a session token is present.
 
 use hmac::{Hmac, Mac};

--- a/src/worker_rt.rs
+++ b/src/worker_rt.rs
@@ -63,6 +63,7 @@ use futures_util::{Stream, StreamExt};
 use serde_json::{json, Value};
 use worker::*;
 
+use crate::landing::{landing_page_html, LANDING_CACHE_CONTROL, LANDING_CONTENT_SECURITY_POLICY};
 use crate::policy::decision::{Phase, PolicyDecision};
 use crate::policy::engine::EngineOptions;
 use crate::policy::metering::{extract_actual_usage_priced, ActualUsage, StreamUsageScanner};
@@ -78,17 +79,17 @@ use crate::policy::PolicyEngine;
 use crate::routing::{
     apply_input_transforms, apply_output_transforms, authorization_bearer_token,
     bedrock_converse_to_openai, estimate_admission_input_tokens, flatten_input_text,
-    flatten_output_text, normalize_base_url,
+    flatten_output_text, is_cross_provider_credential_header, normalize_base_url,
     openai_to_anthropic_messages_with_assumed_output_tokens, openai_to_bedrock_converse,
     prepare_strict_admission_body, resolve_provider, transform_anthropic_to_openai_format,
-    upstream_url_with_base, validate_strict_anthropic_base_url, validate_strict_openai_base_url,
-    ANTHROPIC_BASE_URL_VAR, OPENAI_BASE_URL_VAR,
+    upstream_url_with_base, validate_aws_region, validate_strict_anthropic_base_url,
+    validate_strict_openai_base_url, validate_worker_bedrock_request, ANTHROPIC_BASE_URL_VAR,
+    BEDROCK_DEFAULT_REGION, OPENAI_BASE_URL_VAR,
 };
 use crate::sigv4;
 
 /// Default Bedrock model + region (mirrors the native `BedrockProvider`).
 const BEDROCK_DEFAULT_MODEL: &str = "amazon.titan-text-premier-v1:0";
-const BEDROCK_DEFAULT_REGION: &str = "us-east-1";
 /// The platform reaps a pending reservation after 15 minutes. End an edge
 /// provider call well before that lease can be released under a still-live SSE
 /// stream; Cloudflare otherwise permits incoming Worker requests indefinitely.
@@ -104,7 +105,7 @@ struct BedrockCreds {
 }
 
 /// Extract Bedrock credentials from request headers (supports temporary creds
-/// via `x-aws-session-token`, which the native path does not).
+/// via `x-aws-session-token`, matching the native path).
 fn bedrock_credentials(req: &Request) -> Option<BedrockCreds> {
     let h = req.headers();
     let access_key = h
@@ -315,7 +316,7 @@ fn copy_headers_excluding(src: &Headers, skip: &[&str]) -> Result<Headers> {
         let lower = k.to_ascii_lowercase();
         if skip.contains(&lower.as_str())
             || lower.starts_with("x-noveum-")
-            || lower.starts_with("x-aws-")
+            || is_cross_provider_credential_header(&lower)
             || connection_tokens.iter().any(|token| token == &lower)
         {
             continue;
@@ -429,6 +430,22 @@ fn invalid_stateful_input(message: &str) -> Result<Response> {
             "type": "invalid_request_error",
             "param": Value::Null,
             "code": "unsupported_stateful_input",
+        }
+    }))?
+    .with_headers(headers)
+    .with_status(400))
+}
+
+/// Provider-shaped 400 for a feature that this runtime cannot implement.
+fn unsupported_feature(message: &str) -> Result<Response> {
+    let headers = Headers::new();
+    headers.set("content-type", "application/json")?;
+    Ok(Response::from_json(&json!({
+        "error": {
+            "message": message,
+            "type": "invalid_request_error",
+            "param": Value::Null,
+            "code": "unsupported_feature",
         }
     }))?
     .with_headers(headers)
@@ -840,6 +857,16 @@ async fn proxy(
 ) -> Result<Response> {
     let path = req.path();
 
+    if matches!(req.method(), Method::Get | Method::Head) && path == "/" {
+        let mut response = Response::from_html(landing_page_html("cloudflare-worker"))?;
+        let headers = response.headers_mut();
+        headers.set("content-security-policy", LANDING_CONTENT_SECURITY_POLICY)?;
+        headers.set("x-content-type-options", "nosniff")?;
+        headers.set("referrer-policy", "no-referrer")?;
+        headers.set("cache-control", LANDING_CACHE_CONTROL)?;
+        return Ok(response);
+    }
+
     if path == "/health" {
         return Response::from_json(&json!({
             "status": "healthy",
@@ -1072,10 +1099,25 @@ async fn proxy(
                 "Bedrock requires x-aws-access-key-id and x-aws-secret-access-key headers",
             );
         };
+        if let Err(message) = validate_aws_region(&credentials.region) {
+            return error_response(400, "invalid_request_error", &message);
+        }
         Some(credentials)
     } else {
         None
     };
+    if is_bedrock {
+        let Some(body) = body_json.as_ref() else {
+            return error_response(
+                400,
+                "invalid_request_error",
+                "Bedrock requires a valid JSON chat-completions body",
+            );
+        };
+        if let Err(message) = validate_worker_bedrock_request(body) {
+            return unsupported_feature(&message);
+        }
+    }
     if !is_anthropic && !is_bedrock {
         let authorization = req.headers().get("authorization").ok().flatten();
         let bearer = authorization

--- a/tests/.env.test.example
+++ b/tests/.env.test.example
@@ -6,24 +6,39 @@
 # It is separate from your production .env file to avoid conflicts
 #
 # You can place the .env.test file in either:
-# - The project root (./env.test)
+# - The project root (.env.test)
 # - The tests directory (tests/.env.test)
 #
-# The tests will check both locations, but .env.test will always take priority over .env
+# The tests check both locations. A root .env.test takes priority over
+# tests/.env.test; the standard production .env file is never read.
 
 # Gateway URL (default: http://localhost:3000)
 GATEWAY_URL=http://localhost:3000
 
 # Provider API Keys - Add keys for the providers you want to test
 # ===============================================================
-# At minimum, you need either OpenAI or Anthropic key to run the default tests
+# The complete/scheduled matrix needs credentials for every provider below.
+# One provider key is sufficient only when you filter the test run to that
+# provider.
 OPENAI_API_KEY=your_openai_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
 
-# Optional provider keys - Only needed if you add tests for these providers
+# Optional model overrides. Blank/unset values use the checked-in model that
+# was verified during the latest production release.
+OPENAI_TEST_MODEL=
+ANTHROPIC_TEST_MODEL=
+
+# Required for the current complete/scheduled matrix; omit only when running a
+# provider-filtered test that does not exercise them.
 GROQ_API_KEY=your_groq_api_key
 FIREWORKS_API_KEY=your_fireworks_api_key
 TOGETHER_API_KEY=your_together_api_key
+GROQ_TEST_MODEL=
+FIREWORKS_TEST_MODEL=
+TOGETHER_TEST_MODEL=
+
+# Reserved for future provider fixtures. The current full matrix does not read
+# these variables.
 MISTRAL_API_KEY=your_mistral_api_key
 COHERE_API_KEY=your_cohere_api_key
 GEMINI_API_KEY=your_gemini_api_key
@@ -35,4 +50,8 @@ PERPLEXITY_API_KEY=your_perplexity_api_key
 # AWS Bedrock Credentials - Only needed for Bedrock provider tests
 AWS_ACCESS_KEY_ID=your_aws_access_key_id
 AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
-AWS_REGION=us-east-1 
+# Recommended for short-lived STS credentials; leave blank only when the
+# configured access key does not require a session token.
+AWS_SESSION_TOKEN=
+AWS_REGION=us-east-1
+BEDROCK_TEST_MODEL=

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,8 +19,11 @@ The tests are organized as follows:
 To run these tests, you need:
 
 1. A running instance of the AI Gateway (either locally or in a development environment)
-2. API keys for the providers you want to test
-3. A `.env.test` file with the required environment variables
+2. Credentials for all six current fixtures (OpenAI, Anthropic, Groq,
+   Fireworks, Together, and Bedrock) in an unfiltered/full run, or the selected
+   provider's credentials when using a provider-specific filter
+3. Provider credentials supplied through the environment or an ignored
+   `.env.test` file
 
 ## Environment Setup
 
@@ -31,13 +34,16 @@ The AI Gateway uses different environment files for different purposes:
 - **Production**: Uses the standard `.env` file in the project root
 - **Tests**: Uses a separate `.env.test` file to avoid conflicts with production settings
 
-For running tests, creating a `.env.test` file is recommended to keep your test configuration separate from your production settings.
+Prefer short-lived/development credentials exported by your shell or secret
+manager. If you use `.env.test`, the repository ignores it; never copy a
+production credential into source control, logs, issues, or pull requests.
 
 ### Setting Up Test Environment
 
-1. Copy the sample environment file and modify it with your actual keys:
+1. Copy the sample environment file and restrict it to your user:
    ```bash
    cp tests/.env.test.example .env.test
+   chmod 600 .env.test
    ```
 
 2. Edit the `.env.test` file to include your actual API keys and configuration:
@@ -55,25 +61,39 @@ For running tests, creating a `.env.test` file is recommended to keep your test 
    # AWS Bedrock Credentials
    AWS_ACCESS_KEY_ID=your_aws_access_key_id
    AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+   AWS_SESSION_TOKEN=your_temporary_session_token
    AWS_REGION=us-east-1
    ```
 
-> **Note**: You can place the `.env.test` file either in the project root directory or in the `tests` directory. The tests will check both locations, prioritizing `.env.test` over the standard `.env` file.
+> **Note**: You can place the file at either `.env.test` in the project root or
+> `tests/.env.test`. The root `.env.test` takes priority. The integration
+> harness never reads the standard production `.env` file.
 
 ## Provider-Specific Test Information
 
 ### AWS Bedrock
 
-The AWS Bedrock integration test uses `amazon.titan-text-express-v1` by default. Unlike other providers that use API keys, Bedrock uses AWS credentials for authentication. The fixture is intentionally not changed without first verifying that the replacement model is enabled for the smoke-test AWS account.
+The native Bedrock integration test uses the production-verified
+`amazon.nova-micro-v1:0` by default. Unlike the other providers, Bedrock uses
+AWS credentials. Prefer a short-lived STS session and include
+`AWS_SESSION_TOKEN`. The native server validates buffered and ConverseStream
+responses; the Cloudflare Worker is buffered-only in 2.0.1 and rejects
+`stream:true` before admission or AWS.
 
 - **AWS_ACCESS_KEY_ID**: Your AWS access key with Bedrock permissions
 - **AWS_SECRET_ACCESS_KEY**: Your AWS secret key
+- **AWS_SESSION_TOKEN**: Required when using temporary AWS credentials
 - **AWS_REGION**: The AWS region where Bedrock is available (e.g., us-east-1)
 
 The test validates that:
 1. Request IDs are properly extracted from the AWS Bedrock response headers
 2. Streaming and non-streaming modes work correctly
 3. Token usage is present and correct in the gateway response
+
+The checked-in provider defaults were verified on 2026-08-24. Override one
+without editing source by setting `OPENAI_TEST_MODEL`, `ANTHROPIC_TEST_MODEL`,
+`GROQ_TEST_MODEL`, `TOGETHER_TEST_MODEL`, `FIREWORKS_TEST_MODEL`, or
+`BEDROCK_TEST_MODEL`. Empty variables retain the verified default.
 
 ## Running the Tests
 
@@ -157,7 +177,10 @@ If you encounter test failures, check the following:
 
 3. **Console Output**: Look at the test output for detailed error messages, which often point to specific configuration issues.
 
-5. **Environment File Not Found**: The tests will show which environment file was loaded. If you see "Warning: Neither .env.test nor .env files were found", you need to create one of these files with your test configuration.
+4. **Environment File Not Found**: If no `.env.test` is found, the tests use
+   only variables already exported by the caller. Create an ignored
+   `.env.test` or export the required values; the harness never falls back to
+   the repository's production `.env`.
 
 ## Extending the Tests
 
@@ -203,7 +226,10 @@ pub mod groq_test; // Add the new module here
 
 3. **Test Failures**: The tests validate the gateway's proxied response (status, OpenAI-compatible shape, token usage). If tests fail, review the test output for details on which validation failed.
 
-5. **Environment File Not Found**: The tests will show which environment file was loaded. If you see "Warning: Neither .env.test nor .env files were found", you need to create one of these files with your test configuration.
+4. **Environment File Not Found**: If no `.env.test` is found, the tests use
+   only variables already exported by the caller. Create an ignored
+   `.env.test` or export the required values; the harness never falls back to
+   the repository's production `.env`.
 
 ### Viewing Test Logs
 
@@ -220,7 +246,8 @@ This will provide more information about request processing and metric extractio
 The common test module provides a flexible way to customize test cases. You can adjust the test parameters using the fluent interface provided by `ProviderTestConfig`:
 
 ```rust
-let config = ProviderTestConfig::new("openai", "OPENAI_API_KEY", "gpt-5.6-luna")
+let config = ProviderTestConfig::new("openai", "OPENAI_API_KEY", "gpt-4o-mini")
+    .with_model_from_env("OPENAI_TEST_MODEL")
     .with_prompt("Explain quantum computing in simple terms")
     .with_max_completion_tokens(200);
 ```

--- a/tests/integration/anthropic_test.rs
+++ b/tests/integration/anthropic_test.rs
@@ -2,14 +2,24 @@ use super::common::{run_non_streaming_test, run_streaming_test, ProviderTestConf
 
 #[tokio::test]
 async fn test_anthropic_non_streaming() {
-    let config = ProviderTestConfig::new("anthropic", "ANTHROPIC_API_KEY", "claude-sonnet-5")
-        .with_max_completion_tokens(300);
+    let config = ProviderTestConfig::new(
+        "anthropic",
+        "ANTHROPIC_API_KEY",
+        "claude-haiku-4-5-20251001",
+    )
+    .with_model_from_env("ANTHROPIC_TEST_MODEL")
+    .with_max_completion_tokens(300);
     run_non_streaming_test(&config).await;
 }
 
 #[tokio::test]
 async fn test_anthropic_streaming() {
-    let config = ProviderTestConfig::new("anthropic", "ANTHROPIC_API_KEY", "claude-sonnet-5")
-        .with_max_completion_tokens(300);
+    let config = ProviderTestConfig::new(
+        "anthropic",
+        "ANTHROPIC_API_KEY",
+        "claude-haiku-4-5-20251001",
+    )
+    .with_model_from_env("ANTHROPIC_TEST_MODEL")
+    .with_max_completion_tokens(300);
     run_streaming_test(&config).await;
 }

--- a/tests/integration/bedrock_test.rs
+++ b/tests/integration/bedrock_test.rs
@@ -2,24 +2,19 @@ use super::common::{run_non_streaming_test, run_streaming_test, ProviderTestConf
 
 #[tokio::test]
 async fn test_bedrock_non_streaming() {
-    // Use a model that's likely to be available to all AWS accounts with Bedrock access
-    let config = ProviderTestConfig::new(
-        "bedrock",
-        "AWS_ACCESS_KEY_ID",
-        "amazon.titan-text-express-v1",
-    )
-    .with_max_tokens(300);
+    // Verified against the release smoke-test AWS account on 2026-08-24.
+    let config = ProviderTestConfig::new("bedrock", "AWS_ACCESS_KEY_ID", "amazon.nova-micro-v1:0")
+        .with_model_from_env("BEDROCK_TEST_MODEL")
+        .with_max_tokens(300);
     run_non_streaming_test(&config).await;
 }
 
 #[tokio::test]
 async fn test_bedrock_streaming() {
-    // Use a model that's likely to be available to all AWS accounts with Bedrock access
-    let config = ProviderTestConfig::new(
-        "bedrock",
-        "AWS_ACCESS_KEY_ID",
-        "amazon.titan-text-express-v1",
-    )
-    .with_max_tokens(300);
+    // Native uses ConverseStream; the Cloudflare Worker intentionally rejects
+    // Bedrock streaming until its AWS event-stream transport is implemented.
+    let config = ProviderTestConfig::new("bedrock", "AWS_ACCESS_KEY_ID", "amazon.nova-micro-v1:0")
+        .with_model_from_env("BEDROCK_TEST_MODEL")
+        .with_max_tokens(300);
     run_streaming_test(&config).await;
 }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -1,4 +1,4 @@
-use dotenv::from_filename;
+use dotenvy::from_filename;
 use futures_util::StreamExt;
 use reqwest::StatusCode;
 use reqwest::{
@@ -74,6 +74,32 @@ impl ProviderTestConfig {
 #[cfg(test)]
 mod config_tests {
     use super::ProviderTestConfig;
+    use std::{env, fs};
+
+    #[test]
+    fn dotenvy_from_filename_loads_values_without_overriding_the_process() {
+        let suffix = uuid::Uuid::new_v4().simple().to_string().to_uppercase();
+        let file_key = format!("NOVEUM_DOTENVY_FILE_{suffix}");
+        let process_key = format!("NOVEUM_DOTENVY_PROCESS_{suffix}");
+        let path = env::temp_dir().join(format!("noveum-dotenvy-{suffix}.env"));
+
+        env::remove_var(&file_key);
+        env::set_var(&process_key, "from-process");
+        fs::write(
+            &path,
+            format!("{file_key}=from-file\n{process_key}=from-file\n"),
+        )
+        .unwrap();
+
+        dotenvy::from_filename(&path).unwrap();
+
+        assert_eq!(env::var(&file_key).unwrap(), "from-file");
+        assert_eq!(env::var(&process_key).unwrap(), "from-process");
+
+        env::remove_var(file_key);
+        env::remove_var(process_key);
+        fs::remove_file(path).unwrap();
+    }
 
     #[test]
     fn model_override_uses_only_a_non_empty_environment_value() {
@@ -331,7 +357,7 @@ pub async fn run_non_streaming_test(config: &ProviderTestConfig) {
 struct StreamingSmokeState {
     data_chunks: Vec<Value>,
     saw_done: bool,
-    saw_usage: bool,
+    latest_data_has_usage: bool,
 }
 
 impl StreamingSmokeState {
@@ -346,7 +372,7 @@ impl StreamingSmokeState {
         }
         if let Some(json_str) = line.strip_prefix("data: ") {
             if let Ok(json) = serde_json::from_str::<Value>(json_str) {
-                self.saw_usage |= json.get("usage").is_some_and(|usage| {
+                self.latest_data_has_usage = json.get("usage").is_some_and(|usage| {
                     usage.get("prompt_tokens").and_then(Value::as_u64).is_some()
                         && usage
                             .get("completion_tokens")
@@ -365,7 +391,7 @@ impl StreamingSmokeState {
         if !self.saw_done {
             return Err("Streaming response ended without the required data: [DONE] marker");
         }
-        if !self.saw_usage {
+        if !self.latest_data_has_usage {
             return Err("Streaming response ended without terminal token usage");
         }
         Ok(())
@@ -472,6 +498,21 @@ mod tests {
         let message = state
             .validate_complete()
             .expect_err("a stream without terminal usage must fail the smoke test");
+        assert!(message.contains("usage"), "unexpected failure: {message}");
+    }
+
+    #[test]
+    fn streaming_smoke_requires_usage_on_the_final_data_event() {
+        let mut state = StreamingSmokeState::default();
+        state.process_line(
+            r#"data: {"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}"#,
+        );
+        state.process_line(r#"data: {"choices":[{"delta":{"content":"late"}}]}"#);
+        state.process_line("data: [DONE]");
+
+        let message = state
+            .validate_complete()
+            .expect_err("usage on an earlier event must not satisfy terminal usage");
         assert!(message.contains("usage"), "unexpected failure: {message}");
     }
 

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -52,6 +52,50 @@ impl ProviderTestConfig {
         self.output_limit_field = OutputLimitField::MaxCompletionTokens;
         self
     }
+
+    /// Override the verified default model for a scheduled/manual smoke run.
+    /// Empty or whitespace-only repository variables intentionally keep the
+    /// checked-in default so a missing optional override cannot break CI.
+    pub fn with_model_from_env(mut self, env_var_name: &str) -> Self {
+        // Provider fixtures construct their config before `get_api_key` runs;
+        // load the ignored test environment here so file-backed overrides and
+        // workflow-provided variables have identical precedence.
+        init_test_env();
+        if let Ok(value) = env::var(env_var_name) {
+            let value = value.trim();
+            if !value.is_empty() {
+                self.model = value.to_string();
+            }
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::ProviderTestConfig;
+
+    #[test]
+    fn model_override_uses_only_a_non_empty_environment_value() {
+        const KEY: &str = "NOVEUM_TEST_ONLY_PROVIDER_MODEL_OVERRIDE";
+        std::env::remove_var(KEY);
+
+        let default = ProviderTestConfig::new("test", "TEST_API_KEY", "default-model")
+            .with_model_from_env(KEY);
+        assert_eq!(default.model, "default-model");
+
+        std::env::set_var(KEY, "   ");
+        let blank = ProviderTestConfig::new("test", "TEST_API_KEY", "default-model")
+            .with_model_from_env(KEY);
+        assert_eq!(blank.model, "default-model");
+
+        std::env::set_var(KEY, " verified-model ");
+        let overridden = ProviderTestConfig::new("test", "TEST_API_KEY", "default-model")
+            .with_model_from_env(KEY);
+        assert_eq!(overridden.model, "verified-model");
+
+        std::env::remove_var(KEY);
+    }
 }
 
 /// Initialize environment variables from .env.test file for tests
@@ -67,11 +111,9 @@ pub fn init_test_env() {
     }
 
     if !loaded_test_env {
-        if dotenv::dotenv().is_ok() {
-            println!("No .env.test found. Using .env file instead.");
-        } else {
-            println!("Warning: Neither .env.test nor .env files were found. Make sure you have proper environment variables set.");
-        }
+        println!(
+            "No .env.test found. Using only environment variables already exported by the caller."
+        );
     }
 }
 
@@ -96,6 +138,14 @@ pub fn setup_test_headers(provider: &str, api_key: &str) -> HeaderMap {
                 "x-aws-secret-access-key",
                 HeaderValue::from_str(&aws_secret_key).unwrap(),
             );
+            if let Ok(session_token) = env::var("AWS_SESSION_TOKEN") {
+                if !session_token.trim().is_empty() {
+                    headers.insert(
+                        "x-aws-session-token",
+                        HeaderValue::from_str(session_token.trim()).unwrap(),
+                    );
+                }
+            }
             headers.insert("x-aws-region", HeaderValue::from_str(&aws_region).unwrap());
         }
         _ => {
@@ -145,6 +195,18 @@ pub fn create_test_request_body(config: &ProviderTestConfig, stream: bool) -> Va
         OutputLimitField::MaxCompletionTokens => "max_completion_tokens",
     };
     body[field] = json!(config.max_tokens);
+    if stream
+        && matches!(
+            config.provider_name.to_ascii_lowercase().as_str(),
+            "openai" | "groq"
+        )
+    {
+        // These APIs support OpenAI's explicit usage option. Together and
+        // Fireworks report usage in their final chunks without this
+        // undocumented request field; Anthropic/Bedrock usage comes from the
+        // gateway's response translators.
+        body["stream_options"] = json!({"include_usage": true});
+    }
     body
 }
 
@@ -269,6 +331,7 @@ pub async fn run_non_streaming_test(config: &ProviderTestConfig) {
 struct StreamingSmokeState {
     data_chunks: Vec<Value>,
     saw_done: bool,
+    saw_usage: bool,
 }
 
 impl StreamingSmokeState {
@@ -283,6 +346,13 @@ impl StreamingSmokeState {
         }
         if let Some(json_str) = line.strip_prefix("data: ") {
             if let Ok(json) = serde_json::from_str::<Value>(json_str) {
+                self.saw_usage |= json.get("usage").is_some_and(|usage| {
+                    usage.get("prompt_tokens").and_then(Value::as_u64).is_some()
+                        && usage
+                            .get("completion_tokens")
+                            .and_then(Value::as_u64)
+                            .is_some()
+                });
                 self.data_chunks.push(json);
             }
         }
@@ -294,6 +364,9 @@ impl StreamingSmokeState {
         }
         if !self.saw_done {
             return Err("Streaming response ended without the required data: [DONE] marker");
+        }
+        if !self.saw_usage {
+            return Err("Streaming response ended without terminal token usage");
         }
         Ok(())
     }
@@ -391,10 +464,25 @@ mod tests {
     }
 
     #[test]
+    fn streaming_smoke_rejects_a_stream_without_terminal_usage() {
+        let mut state = StreamingSmokeState::default();
+        state.process_line(r#"data: {"choices":[{"delta":{"content":"hello"}}]}"#);
+        state.process_line("data: [DONE]");
+
+        let message = state
+            .validate_complete()
+            .expect_err("a stream without terminal usage must fail the smoke test");
+        assert!(message.contains("usage"), "unexpected failure: {message}");
+    }
+
+    #[test]
     fn streaming_smoke_accepts_tool_calls_without_text_content() {
         let mut state = StreamingSmokeState::default();
         state.process_line(
             r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"lookup","arguments":"{}"}}]}}]}"#,
+        );
+        state.process_line(
+            r#"data: {"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}"#,
         );
         state.process_line("data: [DONE]");
 
@@ -403,11 +491,28 @@ mod tests {
 
     #[test]
     fn request_body_can_select_max_completion_tokens_without_leaking_max_tokens() {
-        let config = ProviderTestConfig::new("openai", "OPENAI_API_KEY", "gpt-5.6-luna")
+        let config = ProviderTestConfig::new("openai", "OPENAI_API_KEY", "gpt-4o-mini")
             .with_max_completion_tokens(16);
         let body = create_test_request_body(&config, false);
 
         assert_eq!(body["max_completion_tokens"], 16);
         assert!(body.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn streaming_smoke_requests_terminal_usage() {
+        let config = ProviderTestConfig::new("openai", "OPENAI_API_KEY", "gpt-4o-mini");
+        let body = create_test_request_body(&config, true);
+
+        assert_eq!(body["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn streaming_smoke_does_not_send_undocumented_usage_options() {
+        for provider in ["together", "fireworks"] {
+            let config = ProviderTestConfig::new(provider, "TEST_API_KEY", "verified-model");
+            let body = create_test_request_body(&config, true);
+            assert!(body.get("stream_options").is_none(), "{provider}: {body}");
+        }
     }
 }

--- a/tests/integration/fireworks_test.rs
+++ b/tests/integration/fireworks_test.rs
@@ -5,8 +5,9 @@ async fn test_fireworks_non_streaming() {
     let config = ProviderTestConfig::new(
         "fireworks",
         "FIREWORKS_API_KEY",
-        "accounts/fireworks/models/llama-v3p2-11b-vision-instruct",
+        "accounts/fireworks/models/deepseek-v4-flash-0731",
     )
+    .with_model_from_env("FIREWORKS_TEST_MODEL")
     .with_max_tokens(300)
     .with_prompt("What is the history of AI?"); // Using a text-only prompt for non-streaming test
     run_non_streaming_test(&config).await;
@@ -17,8 +18,9 @@ async fn test_fireworks_streaming() {
     let config = ProviderTestConfig::new(
         "fireworks",
         "FIREWORKS_API_KEY",
-        "accounts/fireworks/models/llama-v3p2-11b-vision-instruct",
+        "accounts/fireworks/models/deepseek-v4-flash-0731",
     )
+    .with_model_from_env("FIREWORKS_TEST_MODEL")
     .with_max_tokens(300)
     .with_prompt("What is the history of AI?"); // Using a text-only prompt for streaming test
     run_streaming_test(&config).await;

--- a/tests/integration/groq_test.rs
+++ b/tests/integration/groq_test.rs
@@ -2,14 +2,16 @@ use super::common::{run_non_streaming_test, run_streaming_test, ProviderTestConf
 
 #[tokio::test]
 async fn test_groq_non_streaming() {
-    let config =
-        ProviderTestConfig::new("groq", "GROQ_API_KEY", "openai/gpt-oss-20b").with_max_tokens(300);
+    let config = ProviderTestConfig::new("groq", "GROQ_API_KEY", "openai/gpt-oss-20b")
+        .with_model_from_env("GROQ_TEST_MODEL")
+        .with_max_tokens(300);
     run_non_streaming_test(&config).await;
 }
 
 #[tokio::test]
 async fn test_groq_streaming() {
-    let config =
-        ProviderTestConfig::new("groq", "GROQ_API_KEY", "openai/gpt-oss-20b").with_max_tokens(300);
+    let config = ProviderTestConfig::new("groq", "GROQ_API_KEY", "openai/gpt-oss-20b")
+        .with_model_from_env("GROQ_TEST_MODEL")
+        .with_max_tokens(300);
     run_streaming_test(&config).await;
 }

--- a/tests/integration/openai_test.rs
+++ b/tests/integration/openai_test.rs
@@ -2,14 +2,16 @@ use super::common::{run_non_streaming_test, run_streaming_test, ProviderTestConf
 
 #[tokio::test]
 async fn test_openai_non_streaming() {
-    let config = ProviderTestConfig::new("openai", "OPENAI_API_KEY", "gpt-5.6-luna")
+    let config = ProviderTestConfig::new("openai", "OPENAI_API_KEY", "gpt-4o-mini")
+        .with_model_from_env("OPENAI_TEST_MODEL")
         .with_max_completion_tokens(100);
     run_non_streaming_test(&config).await;
 }
 
 #[tokio::test]
 async fn test_openai_streaming() {
-    let config = ProviderTestConfig::new("openai", "OPENAI_API_KEY", "gpt-5.6-luna")
+    let config = ProviderTestConfig::new("openai", "OPENAI_API_KEY", "gpt-4o-mini")
+        .with_model_from_env("OPENAI_TEST_MODEL")
         .with_max_completion_tokens(100);
     run_streaming_test(&config).await;
 }

--- a/tests/integration/together_test.rs
+++ b/tests/integration/together_test.rs
@@ -7,6 +7,7 @@ async fn test_together_non_streaming() {
         "TOGETHER_API_KEY",
         "meta-llama/Llama-3.3-70B-Instruct-Turbo",
     )
+    .with_model_from_env("TOGETHER_TEST_MODEL")
     .with_max_tokens(512);
     run_non_streaming_test(&config).await;
 }
@@ -18,6 +19,7 @@ async fn test_together_streaming() {
         "TOGETHER_API_KEY",
         "meta-llama/Llama-3.3-70B-Instruct-Turbo",
     )
+    .with_model_from_env("TOGETHER_TEST_MODEL")
     .with_max_tokens(512);
     run_streaming_test(&config).await;
 }

--- a/tests/novaguard_platform.rs
+++ b/tests/novaguard_platform.rs
@@ -1870,6 +1870,36 @@ async fn deterministic_provider_errors_are_rejected_before_admission_or_provider
         .as_str()
         .is_some_and(|message| message.contains("source-region-aware pricing")));
 
+    let malformed_bedrock_region = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .header("x-provider", "bedrock")
+        .header("x-aws-access-key-id", "AKIATEST")
+        .header("x-aws-secret-access-key", "secret")
+        .header(
+            "x-aws-region",
+            "us-east-1.amazonaws.com@attacker.invalid/path?x=",
+        )
+        .body(Body::from(
+            serde_json::to_vec(&json!({
+                "model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "max_tokens": 32,
+                "messages": [{"role":"user","content":"hi"}]
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    let response = app.clone().oneshot(malformed_bedrock_region).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let error: Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(error["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("x-aws-region")));
+
     let native_bedrock = Request::builder()
         .method("POST")
         .uri("/v1/chat/completions")

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,6 +7,11 @@
 # The native binary / Docker image (the published `noveum-ai-gateway` crate) is
 # unaffected by this file — it is a separate deployment shape of the same package.
 name = "noveum-ai-gateway"
+# Preview URLs are intentionally disabled. Deleted preview versions can remain
+# routable at Cloudflare's edge even after the Versions API returns 404; keep
+# this service's version-prefix and alias hosts dark unless a bounded preview
+# campaign explicitly re-enables them and rotates any preview-only credentials.
+preview_urls = false
 # `build/index.js` is the canonical entry point emitted by worker-build. The
 # older `build/worker/shim.mjs` still exists but is only a re-export alias that
 # worker-build keeps for backwards compatibility, so point at the real thing.


### PR DESCRIPTION
## Summary

This is the post-release hardening update for `noveum-ai-gateway` 2.0.1, based directly on the merged and published v2.0.0 commit.

It adds:

- a secure, no-JavaScript `GET`/`HEAD /` landing page and accurate runtime version reporting;
- reader-first deployment, migration, validation, provider, Cloudflare, Docker, and release documentation;
- native `HOST` and `WORKER_THREADS` correctness;
- strict Bedrock credential, STS session-token, AWS-region, and Worker-stream validation;
- maintained AWS Smithy EventStream decoding with prelude/message CRC enforcement;
- cross-provider credential isolation and provider-aware streaming smoke fixtures;
- Docker build-context, non-root runtime, provenance, immutable-tag, and OCI-label hardening;
- disabled Cloudflare preview URLs by default after the deleted-preview-runtime incident;
- version bump and packaged release metadata for 2.0.1.

## Security and correctness

- Native Bedrock rejects missing, blank, non-text, or partial access/secret credentials locally and never falls through to an unsigned request.
- Temporary STS credentials are signed with `x-amz-security-token`; raw `x-aws-*` credential headers are removed before dispatch and are not logged.
- Native and Worker routes validate AWS regions before URL construction, admission, or provider dispatch.
- Worker Bedrock rejects streaming and every present non-Boolean `stream` value before admission or AWS dispatch.
- AWS EventStream frames are decoded by the maintained Smithy parser; corrupt prelude or message CRCs terminate the downstream body before translation.
- Worker generic forwarding strips `x-api-key`; only the selected Anthropic path re-adds its canonical key.
- `dotenvy` replaces the unmaintained `dotenv` crate. The legacy Bedrock parser, `nom 5`, and `lexical-core 0.7.6` dependency chain are absent.
- `cargo audit --deny warnings` and cargo-deny now run with zero advisory waivers.
- Docker sends only Cargo manifests, source, schema, and pricing data to BuildKit; `.env*`, `.dev.vars`, Wrangler state, generated output, and unrelated files are excluded by default.
- The runtime image runs as fixed UID/GID `65532:65532` and is validated with a read-only root filesystem, dropped capabilities, and `no-new-privileges`.
- Docker publication occurs only for an exact `v${Cargo version}` tag whose commit is already contained in trusted `origin/main`. PRs, main pushes, and manual runs are build-only.
- Live-provider smoke jobs reject non-main refs before checkout or secret exposure, and all third-party Actions are immutable-SHA pinned.

## Review follow-up

The valid findings from the first PR review are fixed and regression-tested:

- present non-Boolean Worker Bedrock `stream` values are rejected;
- streaming smoke validation requires usage on the final JSON data event before `[DONE]`;
- Docker health polling has finite connect and response timeouts;
- the Cloudflare bridge-removal runbook matches exact Wrangler 4.120.0 version/secret behavior and keeps every intermediate at zero traffic;
- dated production evidence is explicitly identified as v2.0.0/v57 evidence, not v2.0.1 proof;
- Cargo installation is clearly marked as available only after registry publication.

The TTL suggestion required no code change: credential-to-tenant resolution caches for 300 seconds, while an independently documented tenant-runtime idle eviction occurs after 600 seconds. Both values are intentional and cover different lifecycles.

## Provider and Nova Guard evidence

- Anthropic buffered and SSE translation, tool deltas, terminal usage, `[DONE]`, Bearer/native `x-api-key` auth, admission, and authoritative settlement pass in the 13-phase Workerd suite.
- Organization/project coverage passes 13 shared-tenancy integration tests and 8 org-counter unit tests: entitlement and org mismatch rejection, two-org/two-project isolation, per-project counters, shared org counters, credential isolation/rotation, and no Noveum-key provider leakage.
- Production v2.0.0 remains healthy on both `gate.noveum.ai` and workers.dev. Its dated production matrix passed OpenAI, Anthropic, Groq, Together, Fireworks, Gemini, and OpenRouter buffered/SSE paths.
- A fresh localhost native test used a 15-minute AWS STS session and passed Bedrock buffered plus ConverseStream without persisting or logging credential values.

## Exact-head verification

Reviewed head: `2d90209b9409905127a9bfcc9e78b64ef8f9ed45`

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- library: **514/514**
- Nova Guard platform: **61/61**
- policy integration: **12/12**
- binary runtime regression: **1/1**
- provider harness helpers: **8/8** (no live calls)
- all targets compile; wasm32 no-default-features passes
- strict rustdoc (`-D warnings`) passes
- RustSec audit and cargo-deny advisories/licenses/bans/sources pass with zero ignores
- Cargo publish dry-run passes: **114 files**, 2.1 MiB / 516.5 KiB compressed
- packaged native/WASM checks and **514/514** library tests pass on declared MSRV Rust 1.94.1
- pinned `worker-build 0.8.5`, Wrangler 4.120.0 dry-run, and all **13 Workerd phases** pass
- Workerd concurrency: **16/16** admissions and authoritative completions, all four provider categories **4/4**, zero abandon/error/panic
- final Docker image is healthy as `65532:65532` with a read-only root filesystem and correct 2.0.1/revision labels
- documentation local links/anchors, fences, shell/JSON/YAML examples, rustdoc, package contents, and external links pass
- added-line and untracked-file secret scans pass
- two independent whole-diff audits found no remaining P0/P1/P2 blocker

## Release order after approval

1. Merge only after exact-head CI and independent review are green.
2. Upload the exact merged SHA as a zero-traffic Cloudflare version with previews disabled; verify bindings and a version override/canary before promoting.
3. Re-run production health, authentication, buffered/SSE provider, org/project, logs, and error checks; preserve v2.0.0 Worker v57 as rollback.
4. Publish Cargo 2.0.1 only from the clean exact `origin/main` merge commit, then create the immutable v2.0.1 tag/GitHub release.
5. Let the tag-only Docker workflow publish versioned/`latest` images and verify registries and docs.rs.

No 2.0.1 deployment, Cargo upload, tag, or registry publication has happened yet.
