### PR TITLE
fix: verify public container release metadata

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -96,16 +95,68 @@ jobs:
           git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
           bash scripts/validate_docker_release.sh provenance HEAD refs/remotes/origin/main
 
+  release:
+    name: Publish immutable release images
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: docker
+    concurrency:
+      group: noveum-ai-gateway-container-release
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Revalidate release workflow and exact tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          bash scripts/validate_docker_release.sh workflows
+          VERSION="$(bash scripts/validate_docker_release.sh package-version)"
+          test "$(bash scripts/validate_docker_release.sh mode "${EVENT_NAME}" "${GIT_REF}")" = release
+          echo "CARGO_VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Reverify release commit provenance against main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+          bash scripts/validate_docker_release.sh provenance HEAD refs/remotes/origin/main
+
+      # This runs before either login. Only an authenticated anonymous token
+      # followed by a MANIFEST_UNKNOWN response counts as an absent tag.
+      - name: Prove immutable version tags do not exist
+        run: |
+          set -euo pipefail
+          bash scripts/validate_docker_release.sh release-tags-absent \
+            "${GHCR_IMAGE}:${CARGO_VERSION}" \
+            "${DOCKERHUB_IMAGE}:${CARGO_VERSION}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
       - name: Log in to GitHub Container Registry
-        if: steps.release.outputs.publish == 'true'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract metadata for GHCR
-        if: steps.release.outputs.publish == 'true'
         id: meta-ghcr
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
@@ -115,7 +166,6 @@ jobs:
             type=raw,value=latest,priority=200
 
       - name: Build and push to GitHub Container Registry
-        if: steps.release.outputs.publish == 'true'
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
@@ -130,15 +180,7 @@ jobs:
           # Match local build platform for GHCR build too
           platforms: linux/amd64
 
-      - name: Login to Docker Hub
-        if: steps.release.outputs.publish == 'true'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Build and push to Docker Hub
-        if: steps.release.outputs.publish == 'true'
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
@@ -154,7 +196,6 @@ jobs:
           platforms: linux/amd64
 
       - name: Verify public release images from both registries
-        if: steps.release.outputs.publish == 'true'
         run: |
           set -euo pipefail
           bash scripts/validate_docker_release.sh release-images \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,7 +10,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  GHCR_IMAGE: ghcr.io/noveum/ai-gateway
+  DOCKERHUB_IMAGE: noveum/noveum-ai-gateway
 
 jobs:
   docker:
@@ -108,10 +109,10 @@ jobs:
         id: meta-ghcr
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.GHCR_IMAGE }}
           tags: |
-            type=raw,value=latest
-            type=raw,value=${{ env.CARGO_VERSION }}
+            type=raw,value=${{ env.CARGO_VERSION }},priority=900
+            type=raw,value=latest,priority=200
 
       - name: Build and push to GitHub Container Registry
         if: steps.release.outputs.publish == 'true'
@@ -143,11 +144,20 @@ jobs:
           context: .
           push: true
           tags: |
-            noveum/noveum-ai-gateway:latest
-            noveum/noveum-ai-gateway:${{ env.CARGO_VERSION }}
+            ${{ env.DOCKERHUB_IMAGE }}:latest
+            ${{ env.DOCKERHUB_IMAGE }}:${{ env.CARGO_VERSION }}
           build-args: |
             VERSION=${{ env.CARGO_VERSION }}
             REVISION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
+
+      - name: Verify public release images from both registries
+        if: steps.release.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          bash scripts/validate_docker_release.sh release-images \
+            "${GHCR_IMAGE}:${CARGO_VERSION}" \
+            "${DOCKERHUB_IMAGE}:${CARGO_VERSION}" \
+            "${GITHUB_SHA}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- GHCR release metadata now gives the immutable Cargo-version tag higher
+  priority than `latest`, so `org.opencontainers.image.version` identifies the
+  release instead of the moving alias. After both registry pushes, automation
+  uses an empty temporary Docker configuration to prove that the exact GHCR and
+  Docker Hub tags are anonymously pullable, then reruns OCI, identity,
+  hardening, and health validation on the pulled images.
+
+### Documentation
+
+- Recorded the immutable v2.0.1 GHCR caveat: its OCI version label is `latest`,
+  and anonymous access failed at the 2026-08-24 release check. The Docker Hub
+  v2.0.1 image has the correct version/revision labels. Existing v2.0.1 tags and
+  images must not be overwritten; corrected GHCR metadata requires a later
+  patch release.
+
 ## [2.0.1] - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GHCR release metadata now gives the immutable Cargo-version tag higher
   priority than `latest`, so `org.opencontainers.image.version` identifies the
-  release instead of the moving alias. After both registry pushes, automation
-  uses an empty temporary Docker configuration to prove that the exact GHCR and
-  Docker Hub tags are anonymously pullable, then reruns OCI, identity,
-  hardening, and health validation on the pulled images.
+  release instead of the moving alias. Unprivileged build validation now runs
+  with `contents: read`; only a serialized, tag-only dependent release job has
+  `packages: write` and Docker Hub secrets. Before either login or push, that
+  job requires both exact version tags to return an authenticated anonymous
+  `MANIFEST_UNKNOWN`; existing tags and every unauthorized, ambiguous, or
+  network-failed response abort. After both pushes, automation uses an empty
+  temporary Docker configuration to prove that the exact GHCR and Docker Hub
+  tags are anonymously pullable, then reruns OCI, identity, hardening, and
+  health validation on the pulled images.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -335,6 +335,15 @@ version and source revision and runs as the fixed unprivileged identity
 `65532:65532`. Treat the version tag as immutable and pin the verified registry
 digest for deployment; do not use `latest` as a release identity.
 
+**v2.0.1 GHCR caveat:** the image published to GHCR on 2026-08-24 has
+`org.opencontainers.image.version=latest`, and its package did not allow an
+anonymous pull during the release check. The Docker Hub `2.0.1` image has the
+correct version and revision labels. Do not overwrite or recreate either
+v2.0.1 tag; use the verified Docker Hub digest when exact container metadata is
+required, and correct GHCR through a later patch release. Making the existing
+GHCR package public can restore anonymous access without changing its digest,
+but it cannot repair the immutable v2.0.1 label.
+
 ## Security boundaries
 
 - Provider and Noveum keys are secrets. Do not log them, commit them, embed them

--- a/README.md
+++ b/README.md
@@ -328,12 +328,17 @@ Container automation publishes `2.0.1` and `latest` to both GHCR and Docker Hub
 only when the pushed Git tag is exactly `v2.0.1`, matching the Cargo package
 version, and that tag's commit is already contained in trusted `main`. Pull
 requests, `main` pushes, and manual workflow runs build and exercise the image
-but publish nothing, so they cannot overwrite a release image. The Docker build
-context is deny-by-default and contains only the Cargo manifest/lockfile, Rust
-source, policy schema, and pricing catalog. The release image records the exact
-version and source revision and runs as the fixed unprivileged identity
-`65532:65532`. Treat the version tag as immutable and pin the verified registry
-digest for deployment; do not use `latest` as a release identity.
+with `contents: read` and receive no registry permissions or secrets. A
+serialized tag-only release job depends on that validation and alone receives
+`packages: write` plus Docker Hub credentials. Before either registry login or
+push, it accepts only an anonymous `MANIFEST_UNKNOWN` result for both exact
+version tags; an existing tag, authorization/visibility error, rate limit,
+malformed response, or network failure aborts. The Docker build context is
+deny-by-default and contains only the Cargo manifest/lockfile, Rust source,
+policy schema, and pricing catalog. The release image records the exact version
+and source revision and runs as the fixed unprivileged identity `65532:65532`.
+Treat the version tag as immutable and pin the verified registry digest for
+deployment; do not use `latest` as a release identity.
 
 **v2.0.1 GHCR caveat:** the image published to GHCR on 2026-08-24 has
 `org.opencontainers.image.version=latest`, and its package did not allow an

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -48,9 +48,12 @@ that a Cloudflare, Docker, Kubernetes, or control-plane deployment works. The
 Docker checks prove that PR, `main`, and manual events are build-only, that a
 mismatched release tag or a tag outside trusted `main` is rejected, and that the
 deny-by-default context admits only the release inputs copied by the Dockerfile.
-The workflow-wiring check also proves that credential-bearing provider smoke
-is job-gated to `refs/heads/main` before checkout or secret exposure, then
-checks out the exact scheduled/manual event SHA.
+The workflow-wiring check also proves that Docker build validation has only
+`contents: read`, registry permissions and secrets exist only in the serialized
+tag release job, exact tags are checked before login/push, existing tags fail
+closed, and credential-bearing provider smoke is job-gated to
+`refs/heads/main` before checkout or secret exposure, then checks out the exact
+scheduled/manual event SHA.
 
 ## 2. Publish once
 
@@ -84,7 +87,10 @@ gh release create "v${NOVEUM_RELEASE_VERSION}" --verify-tag \
 The tag push is the **only** publishing trigger for release containers. The
 Docker workflow verifies that the ref is exactly
 `v${Cargo package version}` and that its commit is contained in trusted `main`
-before logging into either registry, then publishes `${NOVEUM_RELEASE_VERSION}`
+in an unprivileged build job. A dependent tag-only job serializes releases,
+repeats the exact-tag and trusted-main checks, and accepts only authenticated
+anonymous `MANIFEST_UNKNOWN` responses for both exact version tags before it
+receives registry credentials. It then publishes `${NOVEUM_RELEASE_VERSION}`
 and `latest` to both
 `ghcr.io/noveum/ai-gateway` and `noveum/noveum-ai-gateway`. Pull requests,
 `main` pushes, and manual workflow runs never publish. Wait for that exact tag's
@@ -97,6 +103,11 @@ pushes, the workflow uses an empty temporary Docker configuration to
 anonymously pull each exact version tag and reruns the hardened runtime/OCI
 validator. This is the release gate for public visibility and registry
 contents; an authenticated push alone is not sufficient.
+
+Do not rerun a failed release blindly. If either exact version tag was created,
+the no-clobber preflight will intentionally reject the rerun. Record which
+registry and digest succeeded, preserve the partial artifacts, and prepare a
+new reviewed patch version instead of overwriting them.
 
 Verify all of the following resolve to the same version and source commit:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,6 +13,13 @@ lockfiles and downloads remain valid.
 - `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, and comparison links agree.
 - The packaged README links repository documentation to the exact release tag,
   not `HEAD` or a moving branch.
+- The GHCR package is explicitly **Public** in package settings. Repository
+  visibility does not make a container package public; GitHub documents the
+  separate setting in
+  [Configuring a package's access control and visibility](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility).
+  GitHub also documents that changing a package to Public cannot be undone, so
+  obtain the package owner's explicit approval and record the change. This
+  workflow validates visibility but never changes it.
 - crates.io credentials are stored in Cargo's credential provider or a scoped
   `CARGO_REGISTRY_TOKEN`, never in the repository or command history.
 
@@ -84,6 +91,13 @@ and `latest` to both
 workflow to finish, then verify both versioned images and record their digests;
 do not infer success from the moving `latest` tag.
 
+The immutable Cargo-version tag has higher metadata priority than `latest`, so
+the generated OCI version label must equal the Cargo version. After both
+pushes, the workflow uses an empty temporary Docker configuration to
+anonymously pull each exact version tag and reruns the hardened runtime/OCI
+validator. This is the release gate for public visibility and registry
+contents; an authenticated push alone is not sufficient.
+
 Verify all of the following resolve to the same version and source commit:
 
 - crates.io version and checksum;
@@ -99,6 +113,17 @@ the generic
 [crates.io package](https://crates.io/crates/noveum-ai-gateway),
 [docs.rs package](https://docs.rs/noveum-ai-gateway), and
 [GitHub releases page](https://github.com/Noveum/ai-gateway/releases).
+
+### v2.0.1 container exception
+
+The 2026-08-24 GHCR v2.0.1 publication used equal-priority raw tags with
+`latest` first. Its immutable image therefore reports
+`org.opencontainers.image.version=latest`, and anonymous access failed during
+the release audit. Docker Hub v2.0.1 is public and correctly labeled. Do not
+rerun the tag by moving/recreating it, and do not overwrite either versioned
+image. Changing the existing GHCR package visibility to Public is a separate
+administrative action that preserves its digest, but it does not repair the
+label; corrected GHCR metadata belongs in a later patch release.
 
 ## Emergency response
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -102,6 +102,23 @@ docker image inspect noveum-ai-gateway:candidate \
   --format '{{ index .Config.Labels "org.opencontainers.image.version" }} {{ index .Config.Labels "org.opencontainers.image.revision" }} {{ .Config.User }}'
 ```
 
+For a tag publication, CI additionally validates the actual registry artifacts
+after both pushes:
+
+```bash
+bash scripts/validate_docker_release.sh release-images \
+  "ghcr.io/noveum/ai-gateway:${NOVEUM_RELEASE_VERSION}" \
+  "noveum/noveum-ai-gateway:${NOVEUM_RELEASE_VERSION}" \
+  "${NOVEUM_RELEASE_REVISION}"
+```
+
+This command uses an empty temporary Docker configuration, so both pulls must
+work anonymously. It then checks the exact Cargo version/revision labels,
+fixed `65532:65532` identity, read-only root filesystem, and versioned health
+response. The immutable GHCR v2.0.1 artifact is a known exception: it reports
+the OCI version as `latest`, and anonymous access failed on 2026-08-24. Do not
+repush it; use Docker Hub v2.0.1 or a corrected later patch release.
+
 ## 5. Live provider matrix
 
 Use a dedicated low-budget test account, low output limits, and non-sensitive

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -92,8 +92,10 @@ checkout or secret exposure and checks out the exact event SHA. The context
 check proves that the deny-by-default
 `.dockerignore` admits only `Cargo.toml`, `Cargo.lock`, `src/`, `schema/`, and
 `pricing/`, while representative `.env`, Wrangler-state, and unlisted files
-cannot be copied. Release tags publish the version and `latest` to GHCR and
-Docker Hub; production still pins the verified version digest.
+cannot be copied. It also runs the hermetic registry preflight regression:
+`MANIFEST_UNKNOWN` passes, while an existing tag, an unrelated 404, or denied
+anonymous token fails. Release tags publish the version and `latest` to GHCR
+and Docker Hub; production still pins the verified version digest.
 
 Confirm the immutable image identifies the release you built:
 
@@ -118,6 +120,21 @@ fixed `65532:65532` identity, read-only root filesystem, and versioned health
 response. The immutable GHCR v2.0.1 artifact is a known exception: it reports
 the OCI version as `latest`, and anonymous access failed on 2026-08-24. Do not
 repush it; use Docker Hub v2.0.1 or a corrected later patch release.
+
+Before either registry login or push, the serialized release job runs:
+
+```bash
+bash scripts/validate_docker_release.sh release-tags-absent \
+  "ghcr.io/noveum/ai-gateway:${NOVEUM_RELEASE_VERSION}" \
+  "noveum/noveum-ai-gateway:${NOVEUM_RELEASE_VERSION}"
+```
+
+Success means both anonymous token requests returned HTTP 200 and both exact
+manifest requests returned HTTP 404 with `MANIFEST_UNKNOWN`. Every other result
+is a failure, including HTTP 200 (tag already exists), authentication or
+visibility errors, `NAME_UNKNOWN`, rate limits, malformed JSON, and network or
+TLS failure. Job-level concurrency prevents two release runs from checking the
+same absent tags at once.
 
 ## 5. Live provider matrix
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -52,6 +52,24 @@ intended registry before rollout, then pin that digest for production. `latest`
 moves only on a matching release tag, but remains mutable and is not a release
 identifier.
 
+GHCR package visibility is separate from repository visibility. A supported
+public image must be anonymously pullable, not merely pullable by the release
+workflow's `GITHUB_TOKEN`. The release workflow therefore uses an empty
+temporary Docker configuration after publication to pull each exact GHCR and
+Docker Hub version tag, then repeats the OCI-label, runtime-identity,
+read-only-root, and health checks on those registry artifacts.
+
+### v2.0.1 registry caveat
+
+The immutable GHCR v2.0.1 image published on 2026-08-24 has
+`org.opencontainers.image.version=latest`; anonymous access also failed during
+the release verification. Docker Hub's v2.0.1 image is publicly pullable and
+has the correct `2.0.1` version label and source revision. Do not repush,
+retag, or recreate v2.0.1. A package administrator may separately make the
+existing GHCR package public without changing its digest, but only a later
+patch release can provide corrected GHCR OCI metadata. Until then, use the
+verified Docker Hub digest when exact container metadata is required.
+
 The repository's `.dockerignore` denies the entire working tree, then admits
 only `Cargo.toml`, `Cargo.lock`, `src/`, `schema/`, and `pricing/`. Docker still
 receives the selected Dockerfile separately. This keeps `.env` files, Wrangler

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -52,12 +52,27 @@ intended registry before rollout, then pin that digest for production. `latest`
 moves only on a matching release tag, but remains mutable and is not a release
 identifier.
 
+Build validation runs on every event with only `contents: read`. The dependent
+release job runs only for `v*` tag pushes, is serialized without canceling a
+running release, and alone receives `packages: write` and Docker Hub secrets.
+Before either registry login or push, it obtains anonymous pull tokens and
+requires both exact version manifests to return HTTP 404 with the Distribution
+error code `MANIFEST_UNKNOWN`. An existing tag or any unauthorized, ambiguous,
+rate-limited, malformed, or network-failed response stops the release. This
+prevents a rerun from overwriting an immutable version tag; serialization keeps
+two release runs from passing the absence check concurrently.
+
 GHCR package visibility is separate from repository visibility. A supported
 public image must be anonymously pullable, not merely pullable by the release
 workflow's `GITHUB_TOKEN`. The release workflow therefore uses an empty
 temporary Docker configuration after publication to pull each exact GHCR and
 Docker Hub version tag, then repeats the OCI-label, runtime-identity,
 read-only-root, and health checks on those registry artifacts.
+
+Because publication cannot be atomic across two registries, a failure after
+one exact tag is pushed is not safely retryable: preflight will reject that
+existing tag. Preserve the partial evidence, do not overwrite it, and publish a
+corrected new patch version after review.
 
 ### v2.0.1 registry caveat
 

--- a/scripts/test_registry_tag_preflight.py
+++ b/scripts/test_registry_tag_preflight.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+"""Hermetic behavior tests for fail-closed container tag preflight."""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+from pathlib import Path
+import subprocess
+import threading
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parent.parent
+VALIDATOR = ROOT / "scripts" / "validate_docker_release.sh"
+with (ROOT / "Cargo.toml").open("rb") as cargo_manifest:
+    VERSION = tomllib.load(cargo_manifest)["package"]["version"]
+class RegistryHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        parts = self.path.split("?", 1)[0].strip("/").split("/")
+        scenario = parts[0]
+
+        if scenario == "network-failure":
+            self.close_connection = True
+            return
+
+        if parts[-1] == "token":
+            if scenario == "auth-denied":
+                self._json(401, {"errors": [{"code": "UNAUTHORIZED"}]})
+            else:
+                self._json(200, {"token": "test-anonymous-token"})
+            return
+
+        if self.headers.get("Authorization") != "Bearer test-anonymous-token":
+            self._json(401, {"errors": [{"code": "UNAUTHORIZED"}]})
+            return
+
+        registry = parts[1]
+        if scenario == "existing-ghcr" and registry == "ghcr":
+            self._json(200, {"schemaVersion": 2})
+        elif scenario == "existing-dockerhub" and registry == "dockerhub":
+            self._json(200, {"schemaVersion": 2})
+        elif scenario == "ambiguous" and registry == "ghcr":
+            self._json(404, {"errors": [{"code": "NAME_UNKNOWN"}]})
+        else:
+            self._json(404, {"errors": [{"code": "MANIFEST_UNKNOWN"}]})
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _json(self, status: int, payload: object) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def run_preflight(port: int, scenario: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "NOVEUM_RELEASE_GHCR_REGISTRY_BASE": f"http://127.0.0.1:{port}/{scenario}/ghcr",
+            "NOVEUM_RELEASE_GHCR_TOKEN_URL": f"http://127.0.0.1:{port}/{scenario}/ghcr/token",
+            "NOVEUM_RELEASE_DOCKERHUB_REGISTRY_BASE": f"http://127.0.0.1:{port}/{scenario}/dockerhub",
+            "NOVEUM_RELEASE_DOCKERHUB_TOKEN_URL": f"http://127.0.0.1:{port}/{scenario}/dockerhub/token",
+        }
+    )
+    return subprocess.run(
+        [
+            "bash",
+            str(VALIDATOR),
+            "release-tags-absent",
+            f"ghcr.io/noveum/ai-gateway:{VERSION}",
+            f"noveum/noveum-ai-gateway:{VERSION}",
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def main() -> None:
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), RegistryHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        missing = run_preflight(server.server_port, "missing")
+        assert missing.returncode == 0, missing.stderr
+
+        for scenario, registry in (
+            ("existing-ghcr", f"ghcr.io/noveum/ai-gateway:{VERSION}"),
+            ("existing-dockerhub", f"noveum/noveum-ai-gateway:{VERSION}"),
+        ):
+            existing = run_preflight(server.server_port, scenario)
+            assert existing.returncode != 0, scenario
+            assert f"Release tag already exists: {registry}" in existing.stderr
+
+        ambiguous = run_preflight(server.server_port, "ambiguous")
+        assert ambiguous.returncode != 0
+        assert "did not return MANIFEST_UNKNOWN" in ambiguous.stderr
+
+        denied = run_preflight(server.server_port, "auth-denied")
+        assert denied.returncode != 0
+        assert "Anonymous registry token request failed" in denied.stderr
+
+        network = run_preflight(server.server_port, "network-failure")
+        assert network.returncode != 0
+        assert "Anonymous registry token request failed" in network.stderr
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    print(
+        "Registry preflight accepts only MANIFEST_UNKNOWN and rejects existing, "
+        "ambiguous, unauthorized, or network-failed tags"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_docker_release.sh
+++ b/scripts/validate_docker_release.sh
@@ -12,6 +12,7 @@ docker_context_validation_tmp=""
 docker_runtime_validation_container=""
 release_provenance_validation_tmp=""
 release_image_validation_tmp=""
+release_tag_preflight_tmp=""
 
 package_version() {
   local version
@@ -144,11 +145,68 @@ self_test_release_provenance() {
 }
 
 validate_workflow_wiring() {
+  local build_job release_job preflight_line first_login_line first_push_line
+  local release_mode_line release_provenance_line workflow_sensitive_count release_sensitive_count
   local docker_workflow provider_workflow classifier_line fetch_line provenance_line runtime_line first_publish_line
   local last_publish_line release_images_line metadata_version_priority metadata_latest_priority
   local build_action_count revision_arg_count smoke_if_line steps_line checkout_line first_secret_line
   docker_workflow="${repository_root}/.github/workflows/docker-build.yml"
   provider_workflow="${repository_root}/.github/workflows/provider-smoke.yml"
+
+  build_job="$(awk '
+    /^  docker:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && !/^  docker:/ { exit }
+    in_job { print }
+  ' "${docker_workflow}")"
+  release_job="$(awk '
+    /^  release:/ { in_job = 1 }
+    in_job && /^  [A-Za-z0-9_-]+:/ && !/^  release:/ { exit }
+    in_job { print }
+  ' "${docker_workflow}")"
+  if [[ "${build_job}" != *"contents: read"* || "${build_job}" == *"packages: write"* ||
+    "${build_job}" == *'${{ secrets.'* || "${build_job}" == *"push: true"* ]]
+  then
+    echo "The build-validation job must have contents:read only and no publication credentials or pushes" >&2
+    return 1
+  fi
+  if [[ -z "${release_job}" || "${release_job}" != *"needs: docker"* ||
+    "${release_job}" != *"packages: write"* || "${release_job}" != *"contents: read"* ||
+    "${release_job}" != *"refs/tags/v"* || "${release_job}" != *"concurrency:"* ||
+    "${release_job}" != *"group:"* || "${release_job}" != *"cancel-in-progress: false"* ||
+    "${release_job}" == *"environment:"* ]]
+  then
+    echo "A serialized tag-only release job must depend on the unprivileged Docker validation job" >&2
+    return 1
+  fi
+  if printf '%s\n' "${build_job}" | grep -Eq '^    if:'; then
+    echo "The unprivileged Docker validation job must run for every workflow event" >&2
+    return 1
+  fi
+
+  workflow_sensitive_count="$(grep -Ec 'push:[[:space:]]*true|\$\{\{[[:space:]]*secrets\.' "${docker_workflow}" || true)"
+  release_sensitive_count="$(printf '%s\n' "${release_job}" | grep -Ec 'push:[[:space:]]*true|\$\{\{[[:space:]]*secrets\.' || true)"
+  if [[ "${workflow_sensitive_count}" -eq 0 || "${workflow_sensitive_count}" -ne "${release_sensitive_count}" ]]; then
+    echo "All registry pushes and secrets must be isolated inside the tag-only release job" >&2
+    return 1
+  fi
+
+  preflight_line="$(grep -n -m1 'validate_docker_release.sh release-tags-absent' "${docker_workflow}" | cut -d: -f1 || true)"
+  first_login_line="$(grep -n -m1 'uses: docker/login-action@' "${docker_workflow}" | cut -d: -f1 || true)"
+  first_push_line="$(grep -n -m1 'push:[[:space:]]*true' "${docker_workflow}" | cut -d: -f1 || true)"
+  if [[ -z "${preflight_line}" || -z "${first_login_line}" || -z "${first_push_line}" ]] ||
+    (( preflight_line >= first_login_line || preflight_line >= first_push_line ))
+  then
+    echo "Both immutable registry tags must be proven absent before any registry login or push" >&2
+    return 1
+  fi
+  release_mode_line="$(grep -n 'validate_docker_release.sh mode' "${docker_workflow}" | tail -n 1 | cut -d: -f1 || true)"
+  release_provenance_line="$(grep -n 'validate_docker_release.sh provenance HEAD refs/remotes/origin/main' "${docker_workflow}" | tail -n 1 | cut -d: -f1 || true)"
+  if [[ -z "${release_mode_line}" || -z "${release_provenance_line}" ]] ||
+    (( release_mode_line >= release_provenance_line || release_provenance_line >= preflight_line ))
+  then
+    echo "The release job must repeat exact-tag and trusted-main provenance checks before registry preflight" >&2
+    return 1
+  fi
 
   classifier_line="$(grep -n -m1 'validate_docker_release.sh mode' "${docker_workflow}" | cut -d: -f1 || true)"
   if [[ -z "${classifier_line}" ]]; then
@@ -212,36 +270,6 @@ validate_workflow_wiring() {
     return 1
   fi
 
-  # Registry credentials and every push-capable Docker step must be guarded by
-  # the validated release output, rather than by a mutable branch name.
-  if ! awk '
-    function finish_step() {
-      if (sensitive && !guarded) {
-        print "Sensitive Docker workflow step is not release-guarded: " step > "/dev/stderr"
-        bad = 1
-      }
-      sensitive = 0
-      guarded = 0
-      step = "<unnamed>"
-    }
-    /^      - / {
-      finish_step()
-      step = $0
-    }
-    /push:[[:space:]]*true/ || /\$\{\{[[:space:]]*secrets\./ ||
-      /validate_docker_release\.sh release-images/ { sensitive = 1 }
-    /if:[[:space:]]*steps\.release\.outputs\.publish[[:space:]]*==[[:space:]]*'"'"'true'"'"'/ {
-      guarded = 1
-    }
-    END {
-      finish_step()
-      exit bad
-    }
-  ' "${docker_workflow}"
-  then
-    return 1
-  fi
-
   smoke_if_line="$(grep -n -m1 "if: github.ref == 'refs/heads/main'" "${provider_workflow}" | cut -d: -f1 || true)"
   steps_line="$(grep -n -m1 '^[[:space:]]*steps:' "${provider_workflow}" | cut -d: -f1 || true)"
   checkout_line="$(grep -n -m1 'uses: actions/checkout@' "${provider_workflow}" | cut -d: -f1 || true)"
@@ -266,6 +294,7 @@ validate_workflow_wiring() {
 
   self_test_release_mode
   self_test_release_provenance
+  python3 "${repository_root}/scripts/test_registry_tag_preflight.py"
   echo "Workflow release and secret-ref guards are wired correctly"
 }
 
@@ -446,6 +475,152 @@ validate_runtime_image() {
   echo "Runtime image is healthy as UID:GID ${runtime_uid}:${runtime_gid} with revision ${revision_label} and a read-only root filesystem"
 }
 
+cleanup_release_tag_preflight() {
+  case "${release_tag_preflight_tmp}" in
+    "${TMPDIR:-/tmp}"/noveum-registry-preflight.*)
+      rm -rf -- "${release_tag_preflight_tmp}"
+      release_tag_preflight_tmp=""
+      ;;
+    "") ;;
+    *)
+      echo "Refusing to remove unexpected registry preflight path: ${release_tag_preflight_tmp}" >&2
+      ;;
+  esac
+}
+
+assert_manifest_absent() {
+  local registry_base="$1"
+  local token_url="$2"
+  local service="$3"
+  local repository="$4"
+  local tag="$5"
+  local display_image="$6"
+  local validation_tmp token_body manifest_body token_status manifest_status token
+
+  if ! command -v curl >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    echo "curl and python3 are required for registry tag preflight" >&2
+    return 1
+  fi
+
+  validation_tmp="$(mktemp -d "${TMPDIR:-/tmp}/noveum-registry-preflight.XXXXXX")"
+  release_tag_preflight_tmp="${validation_tmp}"
+  token_body="${validation_tmp}/token.json"
+  manifest_body="${validation_tmp}/manifest.json"
+  trap cleanup_release_tag_preflight EXIT HUP INT TERM
+
+  if ! token_status="$(curl --silent --show-error --location \
+    --connect-timeout 10 --max-time 30 --max-filesize 1048576 \
+    --output "${token_body}" --write-out '%{http_code}' \
+    --get \
+    --data-urlencode "service=${service}" \
+    --data-urlencode "scope=repository:${repository}:pull" \
+    "${token_url}")"
+  then
+    echo "Anonymous registry token request failed for ${display_image}" >&2
+    return 1
+  fi
+  if [[ "${token_status}" != "200" ]]; then
+    echo "Anonymous registry token request failed for ${display_image} with HTTP ${token_status}" >&2
+    return 1
+  fi
+  if ! token="$(python3 -c '
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+token = payload.get("token") or payload.get("access_token")
+if not isinstance(token, str) or not token or any(ord(char) < 32 or ord(char) == 127 for char in token):
+    raise SystemExit(1)
+print(token, end="")
+' "${token_body}" 2>/dev/null)"
+  then
+    echo "Anonymous registry token response was invalid for ${display_image}" >&2
+    return 1
+  fi
+
+  if ! manifest_status="$(curl --silent --show-error --location \
+    --connect-timeout 10 --max-time 30 --max-filesize 1048576 \
+    --output "${manifest_body}" --write-out '%{http_code}' \
+    --header "Authorization: Bearer ${token}" \
+    --header 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json' \
+    "${registry_base%/}/v2/${repository}/manifests/${tag}")"
+  then
+    echo "Registry manifest request failed for ${display_image}" >&2
+    return 1
+  fi
+  if [[ "${manifest_status}" == "200" ]]; then
+    echo "Release tag already exists: ${display_image}" >&2
+    return 1
+  fi
+  if [[ "${manifest_status}" != "404" ]]; then
+    echo "Registry manifest status was ambiguous for ${display_image}: HTTP ${manifest_status}" >&2
+    return 1
+  fi
+  if ! python3 -c '
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+errors = payload.get("errors")
+if not isinstance(errors, list) or not any(
+    isinstance(error, dict) and error.get("code") == "MANIFEST_UNKNOWN"
+    for error in errors
+):
+    raise SystemExit(1)
+' "${manifest_body}" 2>/dev/null
+  then
+    echo "Registry 404 did not return MANIFEST_UNKNOWN for ${display_image}" >&2
+    return 1
+  fi
+
+  cleanup_release_tag_preflight
+  trap - EXIT HUP INT TERM
+  echo "Release tag is absent: ${display_image}"
+}
+
+validate_release_tags_absent() {
+  local ghcr_image="$1"
+  local dockerhub_image="$2"
+  local expected_version ghcr_reference ghcr_repository ghcr_tag
+  local dockerhub_repository dockerhub_tag
+
+  expected_version="$(package_version)"
+  if [[ "${ghcr_image}" != ghcr.io/*":${expected_version}" || "${ghcr_image}" == *@* ]]; then
+    echo "GHCR preflight requires the exact immutable Cargo tag: ${ghcr_image}" >&2
+    return 1
+  fi
+  if [[ "${dockerhub_image}" != *":${expected_version}" || "${dockerhub_image}" == *@* ||
+    "${dockerhub_image}" == */*/* ]]
+  then
+    echo "Docker Hub preflight requires an owner/image Cargo tag: ${dockerhub_image}" >&2
+    return 1
+  fi
+
+  ghcr_reference="${ghcr_image#ghcr.io/}"
+  ghcr_tag="${ghcr_reference##*:}"
+  ghcr_repository="${ghcr_reference%:*}"
+  dockerhub_tag="${dockerhub_image##*:}"
+  dockerhub_repository="${dockerhub_image%:*}"
+  if [[ -z "${ghcr_repository}" || -z "${dockerhub_repository}" ||
+    "${ghcr_tag}" != "${expected_version}" || "${dockerhub_tag}" != "${expected_version}" ]]
+  then
+    echo "Could not parse exact release image references" >&2
+    return 1
+  fi
+
+  assert_manifest_absent \
+    "${NOVEUM_RELEASE_GHCR_REGISTRY_BASE:-https://ghcr.io}" \
+    "${NOVEUM_RELEASE_GHCR_TOKEN_URL:-https://ghcr.io/token}" \
+    "ghcr.io" "${ghcr_repository}" "${ghcr_tag}" "${ghcr_image}" || return 1
+  assert_manifest_absent \
+    "${NOVEUM_RELEASE_DOCKERHUB_REGISTRY_BASE:-https://registry-1.docker.io}" \
+    "${NOVEUM_RELEASE_DOCKERHUB_TOKEN_URL:-https://auth.docker.io/token}" \
+    "registry.docker.io" "${dockerhub_repository}" "${dockerhub_tag}" "${dockerhub_image}" || return 1
+  echo "Both immutable release tags are absent"
+}
+
 validate_release_images() {
   local ghcr_image="$1"
   local dockerhub_image="$2"
@@ -506,6 +681,7 @@ Usage: scripts/validate_docker_release.sh package-version
        scripts/validate_docker_release.sh workflows
        scripts/validate_docker_release.sh context
        scripts/validate_docker_release.sh runtime-image IMAGE [EXPECTED_REVISION]
+       scripts/validate_docker_release.sh release-tags-absent GHCR_IMAGE DOCKERHUB_IMAGE
        scripts/validate_docker_release.sh release-images GHCR_IMAGE DOCKERHUB_IMAGE EXPECTED_REVISION
 EOF
   return 2
@@ -544,6 +720,10 @@ case "${command_name}" in
   runtime-image)
     [[ "$#" -ge 2 && "$#" -le 3 ]] || usage
     validate_runtime_image "$2" "${3:-}"
+    ;;
+  release-tags-absent)
+    [[ "$#" -eq 3 ]] || usage
+    validate_release_tags_absent "$2" "$3"
     ;;
   release-images)
     [[ "$#" -eq 4 ]] || usage

--- a/scripts/validate_docker_release.sh
+++ b/scripts/validate_docker_release.sh
@@ -11,6 +11,7 @@ repository_root="$(CDPATH= cd -- "${script_dir}/.." && pwd)"
 docker_context_validation_tmp=""
 docker_runtime_validation_container=""
 release_provenance_validation_tmp=""
+release_image_validation_tmp=""
 
 package_version() {
   local version
@@ -144,6 +145,7 @@ self_test_release_provenance() {
 
 validate_workflow_wiring() {
   local docker_workflow provider_workflow classifier_line fetch_line provenance_line runtime_line first_publish_line
+  local last_publish_line release_images_line metadata_version_priority metadata_latest_priority
   local build_action_count revision_arg_count smoke_if_line steps_line checkout_line first_secret_line
   docker_workflow="${repository_root}/.github/workflows/docker-build.yml"
   provider_workflow="${repository_root}/.github/workflows/provider-smoke.yml"
@@ -162,6 +164,44 @@ validate_workflow_wiring() {
     (( fetch_line >= provenance_line || provenance_line >= first_publish_line || runtime_line >= first_publish_line ))
   then
     echo "Docker publication must follow runtime validation and an explicit trusted-main provenance check" >&2
+    return 1
+  fi
+
+  metadata_version_priority="$(awk '
+    /id: meta-ghcr/ { in_metadata = 1; next }
+    in_metadata && /^      - name:/ { exit }
+    in_metadata && /type=raw,value=\$\{\{ env\.CARGO_VERSION \}\},priority=[0-9]+/ {
+      line = $0
+      sub(/^.*priority=/, "", line)
+      sub(/,.*/, "", line)
+      print line
+      exit
+    }
+  ' "${docker_workflow}")"
+  metadata_latest_priority="$(awk '
+    /id: meta-ghcr/ { in_metadata = 1; next }
+    in_metadata && /^      - name:/ { exit }
+    in_metadata && /type=raw,value=latest,priority=[0-9]+/ {
+      line = $0
+      sub(/^.*priority=/, "", line)
+      sub(/,.*/, "", line)
+      print line
+      exit
+    }
+  ' "${docker_workflow}")"
+  if [[ -z "${metadata_version_priority}" || -z "${metadata_latest_priority}" ]] ||
+    (( metadata_version_priority <= metadata_latest_priority ))
+  then
+    echo "The immutable Cargo-version tag must outrank latest in GHCR metadata" >&2
+    return 1
+  fi
+
+  last_publish_line="$(grep -En 'push:[[:space:]]*true' "${docker_workflow}" | tail -n 1 | cut -d: -f1 || true)"
+  release_images_line="$(grep -n -m1 'validate_docker_release.sh release-images' "${docker_workflow}" | cut -d: -f1 || true)"
+  if [[ -z "${last_publish_line}" || -z "${release_images_line}" ]] ||
+    (( release_images_line <= last_publish_line ))
+  then
+    echo "Published release images must be anonymously pulled and validated after both registry pushes" >&2
     return 1
   fi
 
@@ -188,7 +228,8 @@ validate_workflow_wiring() {
       finish_step()
       step = $0
     }
-    /push:[[:space:]]*true/ || /\$\{\{[[:space:]]*secrets\./ { sensitive = 1 }
+    /push:[[:space:]]*true/ || /\$\{\{[[:space:]]*secrets\./ ||
+      /validate_docker_release\.sh release-images/ { sensitive = 1 }
     /if:[[:space:]]*steps\.release\.outputs\.publish[[:space:]]*==[[:space:]]*'"'"'true'"'"'/ {
       guarded = 1
     }
@@ -405,6 +446,56 @@ validate_runtime_image() {
   echo "Runtime image is healthy as UID:GID ${runtime_uid}:${runtime_gid} with revision ${revision_label} and a read-only root filesystem"
 }
 
+validate_release_images() {
+  local ghcr_image="$1"
+  local dockerhub_image="$2"
+  local expected_revision="$3"
+  local expected_version anonymous_config image
+
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required for release-image validation" >&2
+    return 1
+  fi
+  expected_version="$(package_version)"
+  for image in "${ghcr_image}" "${dockerhub_image}"; do
+    if [[ "${image}" != *":${expected_version}" ]]; then
+      echo "Release-image validation requires the immutable ${expected_version} tag, got: ${image}" >&2
+      return 1
+    fi
+  done
+
+  anonymous_config="$(mktemp -d "${TMPDIR:-/tmp}/noveum-anonymous-docker.XXXXXX")"
+  release_image_validation_tmp="${anonymous_config}"
+  cleanup_release_image_validation() {
+    case "${release_image_validation_tmp}" in
+      "${TMPDIR:-/tmp}"/noveum-anonymous-docker.*)
+        rm -rf -- "${release_image_validation_tmp}"
+        release_image_validation_tmp=""
+        ;;
+      "") ;;
+      *)
+        echo "Refusing to remove unexpected Docker config path: ${release_image_validation_tmp}" >&2
+        ;;
+    esac
+  }
+  trap cleanup_release_image_validation EXIT HUP INT TERM
+
+  for image in "${ghcr_image}" "${dockerhub_image}"; do
+    if ! docker --config "${anonymous_config}" pull --platform linux/amd64 "${image}"; then
+      echo "Release image is not anonymously pullable: ${image}" >&2
+      return 1
+    fi
+    if ! (validate_runtime_image "${image}" "${expected_revision}"); then
+      echo "Published release image failed runtime or OCI metadata validation: ${image}" >&2
+      return 1
+    fi
+  done
+
+  cleanup_release_image_validation
+  trap - EXIT HUP INT TERM
+  echo "Both versioned release images are anonymously pullable and match Cargo ${expected_version} at ${expected_revision}"
+}
+
 usage() {
   cat >&2 <<'EOF'
 Usage: scripts/validate_docker_release.sh package-version
@@ -415,6 +506,7 @@ Usage: scripts/validate_docker_release.sh package-version
        scripts/validate_docker_release.sh workflows
        scripts/validate_docker_release.sh context
        scripts/validate_docker_release.sh runtime-image IMAGE [EXPECTED_REVISION]
+       scripts/validate_docker_release.sh release-images GHCR_IMAGE DOCKERHUB_IMAGE EXPECTED_REVISION
 EOF
   return 2
 }
@@ -452,6 +544,10 @@ case "${command_name}" in
   runtime-image)
     [[ "$#" -ge 2 && "$#" -le 3 ]] || usage
     validate_runtime_image "$2" "${3:-}"
+    ;;
+  release-images)
+    [[ "$#" -eq 4 ]] || usage
+    validate_release_images "$2" "$3" "$4"
     ;;
   *)
     usage


### PR DESCRIPTION
## Summary

- make the immutable Cargo-version tag outrank `latest` in `docker/metadata-action`, so the generated OCI version is the release version
- keep PR/main/manual/tag build validation at `contents: read`; isolate `packages: write` and Docker Hub secrets in a serialized tag-only job that depends on successful build/provenance
- before any registry login or push, require both exact version tags to return an anonymous-token HTTP 404 with `MANIFEST_UNKNOWN`; fail closed on an existing tag or every unauthorized/ambiguous/network result
- after both registry pushes, anonymously pull each exact version tag with an empty temporary Docker config and rerun the existing OCI/runtime hardening validator
- document GHCR's separate Public visibility requirement and the immutable v2.0.1 artifact caveat

## Confirmed v2.0.1 artifact issue

The successful tag workflow run `32725169482` built commit `45004a2145acd8ebbbeb49305a86b7cc629d1ba8`. Its two raw metadata tags had equal default priority with `latest` first. The pinned action therefore generated:

- `version=latest`
- `org.opencontainers.image.version=latest`
- tags `ghcr.io/noveum/ai-gateway:latest` and `:2.0.1`

Both GHCR tags were pushed at immutable digest `sha256:51b5c78df06f005eb7acc402aa7ef2bedff012497346cc19196a0bf4e2cd403a`.

Fresh anonymous GHCR manifest and token requests return 401, and anonymous `docker buildx imagetools inspect` cannot pull the package. The current credential cannot read the package visibility field, so this PR records the observable conclusion: v2.0.1 is not anonymously pullable. GitHub documents that public Container registry packages allow anonymous pulls and that package visibility is separate from repository visibility.

Docker Hub v2.0.1 is public and correctly labeled at digest `sha256:3f7b8baf782d0cb76f31c7a750cd5103b82961620898eb66437b6caf92a78dda`.

This PR does **not** move/recreate v2.0.1, repush either image, change package visibility, bump the version, publish Cargo, or deploy Cloudflare.

## Verification

- RED: the new workflow regression rejected the original workflow: `The immutable Cargo-version tag must outrank latest in GHCR metadata`
- RED: permission/no-clobber guards rejected the prior PR head because the build job held `packages: write` and no pre-push absence check existed
- GREEN: `/bin/bash scripts/validate_docker_release.sh workflows`, including:
  - split-job permission, tag gate, dependency, concurrency, and preflight-before-login/push assertions
  - missing tags pass only on `MANIFEST_UNKNOWN`
  - existing GHCR and existing Docker Hub tags fail
  - `NAME_UNKNOWN`, anonymous-token 401, and network failure fail
- exact pinned `docker/metadata-action@c299e40...` replay:
  - historical inputs -> `version=latest`, OCI version `latest`
  - fixed priorities -> `version=2.0.1`, OCI version `2.0.1`
- Bash 3.2 syntax check of `scripts/validate_docker_release.sh`
- Python compilation of `scripts/test_registry_tag_preflight.py`
- PyYAML parse and exact permission/dependency/concurrency assertions for `.github/workflows/docker-build.yml`
- changed-doc fence and local-link validation: 5/5
- new GitHub package-visibility documentation link verified against official GitHub Docs
- `git diff --check`
- immutable-tag argument guard rejects `:latest`
- live read-only v2.0.1 preflight aborts before login on GHCR anonymous-token HTTP 401

The desktop sandbox cannot access a running Docker daemon, so the post-push two-registry pull/runtime helper could not complete locally. The tag-only workflow will execute that retained gate after future pushes; existing v2.0.1 Docker Hub OCI/runtime evidence remains green. The new pre-push registry protocol is independently exercised end to end against a hermetic HTTP registry.

## Release recommendation

Merge this before another release. Separately, with package-owner approval, change the existing GHCR package visibility to Public and verify anonymous access; that preserves its digest but cannot repair v2.0.1's immutable OCI label. Do not overwrite v2.0.1. Because public GHCR plus exact OCI metadata are documented release contracts, publish an artifact-correcting v2.0.2 only through the normal reviewed release process after this change is merged and visibility is confirmed.
