### PR TITLE
feat(worker): load optional Nova Guard policy bundles from Workers KV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Cloudflare Worker: optional Workers KV loading for stateless Nova Guard policy
+  bundles via the `NOVEUM_GUARD_POLICIES_KV` binding and fixed key
+  `nova-guard-policies`. Precedence without the platform bridge is KV → inline
+  `NOVEUM_GUARD_POLICIES` → transparent proxy; the platform bridge still wins
+  when configured. Malformed KV or inline JSON returns 503.
+
 ### Fixed
 
 - GHCR release metadata now gives the immutable Cargo-version tag higher

--- a/docs/CLOUDFLARE_DEPLOYMENT.md
+++ b/docs/CLOUDFLARE_DEPLOYMENT.md
@@ -105,7 +105,7 @@ supplied per request. Platform-managed Nova Guard does require a scoped
 | Server runtime | `workerd` isolate | Tokio + Axum |
 | Bedrock signing | Pure Rust `sha2` + `hmac`; accepts optional session token | Native AWS SDK signer; accepts optional session token |
 | Caller tenancy | Dedicated project only; `NOVEUM_GUARD_TENANCY=shared` is refused with 503 | Dedicated or shared, with tenant derived from `x-noveum-api-key` |
-| Local policy source | Inline Worker var/secret; filesystem paths are unavailable | Inline JSON or file |
+| Local policy source | Optional Workers KV (`NOVEUM_GUARD_POLICIES_KV`, key `nova-guard-policies`) and/or inline Worker var/secret; filesystem paths are unavailable | Inline JSON or file |
 | Stateful inline policy | Inline `cost_cap` / `rate_limit` is refused with 503 because it has no backend | Without platform state, stateful rules fail open and warn |
 | Platform state | Dedicated policy fetch, project/org counters, admission, settlement | Dedicated or per-derived-tenant clients |
 | Deployment-wide cost-mode override | Not implemented; each policy's `enforcementMode` decides | `NOVEUM_GUARD_COST_ENFORCEMENT=strict\|advisory` |

--- a/docs/CLOUDFLARE_WORKER.md
+++ b/docs/CLOUDFLARE_WORKER.md
@@ -254,9 +254,13 @@ describes retention and export options.
   disabled even though the production `workers.dev` route is enabled. Candidate
   smoke tests use a zero-percent deployment plus the version-override header.
 - `NOVEUM_GUARD_POLICIES` — inline `nova-guard.json` (same schema as the native
-  `NOVEUM_GUARD_POLICIES`/file). Setting it activates stateless Nova Guard.
-  Workers KV policy loading is not implemented in this release; use a Worker
-  secret if the bundle must not be committed.
+  `NOVEUM_GUARD_POLICIES`/file). Fallback when KV is bound but the
+  `nova-guard-policies` key is absent or empty. Prefer a Worker secret when the
+  bundle must not be committed.
+- `NOVEUM_GUARD_POLICIES_KV` — optional Workers KV namespace binding. Store the
+  bundle at the fixed key `nova-guard-policies` for global updates without a
+  Worker redeploy (short in-isolate cache, ~60 s). See
+  [Workers KV policy bundles](#workers-kv-policy-bundles).
 - `NOVEUM_GUARD_ENABLED` — `true`/`false` (default `true`; with no policies it's
   still a no-op).
 - `NOVEUM_GUARD_BLOCK_RESPONSE_MODE` — `synthetic_success` (default: HTTP 200 with
@@ -297,10 +301,12 @@ Request bodies over **8 MiB** are rejected with `413`.
 
 The Worker runs Nova Guard in **both** shapes:
 
-* **Inline / stateless** — a `NOVEUM_GUARD_POLICIES` bundle of text policies
-  (`regex_match`, `pii_detection`, secrets, banned terms, model allowlist, JSON
-  schema, token limits), decided entirely from the payload in front of the
-  gateway using the shared deterministic policy engine.
+* **Local / stateless** — a policy bundle from optional Workers KV
+  (`NOVEUM_GUARD_POLICIES_KV`, key `nova-guard-policies`) and/or inline
+  `NOVEUM_GUARD_POLICIES` text policies (`regex_match`, `pii_detection`,
+  secrets, banned terms, model allowlist, JSON schema, token limits), decided
+  entirely from the payload in front of the gateway using the shared
+  deterministic policy engine.
 * **Platform-managed** — set `NOVEUM_API_KEY` + `NOVEUM_GUARD_PROJECT_ID` and
   the Worker fetches the project's *effective* policy set, reads the live
   cost/rate counters, and reserves every request against the platform's
@@ -348,7 +354,11 @@ conservative reservation estimate.
 
 | Configuration | Worker behavior |
 |---|---|
-| `NOVEUM_API_KEY` + `NOVEUM_GUARD_PROJECT_ID` set | **Platform-managed Nova Guard**, in dedicated mode. Policies, live state and admission come from the control plane; any inline `NOVEUM_GUARD_POLICIES` is ignored (with a warning) — the platform is the source of truth. |
+| `NOVEUM_API_KEY` + `NOVEUM_GUARD_PROJECT_ID` set | **Platform-managed Nova Guard**, in dedicated mode. Policies, live state and admission come from the control plane; any Workers KV binding or inline `NOVEUM_GUARD_POLICIES` is ignored (with a warning) — the platform is the source of truth. |
+| `NOVEUM_GUARD_POLICIES_KV` bound, key `nova-guard-policies` holds valid JSON, no bridge | **KV-backed stateless Nova Guard.** Cached ~60 s per isolate; updates propagate globally without redeploying the Worker. |
+| `NOVEUM_GUARD_POLICIES_KV` bound, key absent/empty, inline set, no bridge | **Inline bundle** — KV miss falls through to `NOVEUM_GUARD_POLICIES`. |
+| `NOVEUM_GUARD_POLICIES_KV` bound, KV value malformed | **503**, same as malformed inline — never a silent pass-through. |
+| `NOVEUM_GUARD_POLICIES_KV` bound, KV read fails | **503** — the binding opts into KV as a policy source; transport errors are not ignored. |
 | `x-provider: bedrock` with `stream: true` | **400 `unsupported_feature` before admission or AWS dispatch.** The v2.0.1 Worker supports buffered Converse only; use the native gateway for ConverseStream. |
 | Applicable `mode: enforce`, `action: block`, `enforcementMode: strict` cost cap, but no positive explicit output limit | **400 `missing_output_limit`.** The Worker does not call `/admit` or the provider. Add `max_tokens`, `max_completion_tokens`, or `max_output_tokens`. |
 | Strict request supplies conflicting non-null output-limit aliases | **400 `unsupported_strict_input`.** The Worker does not reserve or forward a request whose admitted and upstream ceilings could differ. |
@@ -358,10 +368,10 @@ conservative reservation estimate.
 | Only *one* of the pair set, or either set to `""` | **503 `gateway_configuration_error`.** A half-applied bridge is still an attempt to enable enforcement; falling through to an unguarded proxy would reward the mistake with a 200. Same matrix as the native `RemoteConfig::from_values`. |
 | Bridge set, but the **first** policy fetch fails | **503.** No policy set is known, so every request would be forwarded unguarded. Override with `NOVEUM_GUARD_ALLOW_UNGUARDED_START=true` (emergency only). |
 | Bridge set, admission returns **503**/times out | `failClosed` decides: a fail-closed strict cap **blocks**; otherwise the request proceeds and the outage is logged. Never an implicit allow. |
-| `NOVEUM_GUARD_POLICIES` containing `cost_cap` or `rate_limit`, **no** bridge | **503.** An inline bundle has no live spend/rate backend, so those policies could only evaluate to "allow" and their `failClosed` flag would be neutralized. Configure the bridge instead. |
-| `NOVEUM_GUARD_POLICIES` set but not valid JSON / not a valid bundle | **503**, plus a structured `console_error`. Parsing the error away would silently drop every policy the operator deployed. |
-| `NOVEUM_GUARD_POLICIES` unset (or empty), no bridge | Transparent proxy — the checked-in default. |
-| `NOVEUM_GUARD_POLICIES` with text policies only | Enforced, identical to native. |
+| Local bundle (KV or inline) containing `cost_cap` or `rate_limit`, **no** bridge | **503.** A KV/inline bundle has no live spend/rate backend, so those policies could only evaluate to "allow" and their `failClosed` flag would be neutralized. Configure the bridge instead. |
+| KV or inline bundle set but not valid JSON / not a valid bundle | **503**, plus a structured `console_error`. Parsing the error away would silently drop every policy the operator deployed. |
+| No KV value, `NOVEUM_GUARD_POLICIES` unset (or empty), no bridge | Transparent proxy — the checked-in default. |
+| KV or inline bundle with text policies only | Enforced, identical to native. |
 
 “Model-scoped-away” in this table assumes a valid JSON body carrying a model.
 When any enforcing/blocking strict cap exists, a non-JSON or multipart request
@@ -371,6 +381,43 @@ Request bodies are capped at **8 MiB**, the same bound as response inspection.
 The declared `Content-Length` is checked before a byte is read, and the cap is
 re-enforced while reading so a chunked body with no (or a lying) length cannot
 allocate the isolate to death. Over the cap → **413**.
+
+### Workers KV policy bundles
+
+Use Workers KV when stateless text policies should change globally without
+redeploying the Worker. Implementation: `src/policy/worker_kv.rs`.
+
+1. Create a KV namespace and add it to `wrangler.toml`:
+
+   ```toml
+   [[kv_namespaces]]
+   binding = "NOVEUM_GUARD_POLICIES_KV"
+   id = "<namespace-id>"
+   ```
+
+2. Write the bundle JSON to the fixed key `nova-guard-policies` (same schema as
+   `nova-guard.json` / `NOVEUM_GUARD_POLICIES`):
+
+   ```bash
+   npx wrangler kv key put --binding=NOVEUM_GUARD_POLICIES_KV \
+     nova-guard-policies --path=./nova-guard.json
+   ```
+
+3. Deploy. Each isolate caches the KV value for ~60 s before re-reading.
+
+**Precedence without the platform bridge:** non-empty KV value → inline
+`NOVEUM_GUARD_POLICIES` → transparent empty bundle. A missing or whitespace-only
+KV key falls through to inline.
+
+**With the platform bridge:** the control plane wins; KV and inline are ignored
+(with a warning if either is configured).
+
+**Limits:** `cost_cap` / `rate_limit` in a KV bundle still require the platform
+bridge — same 503 as inline. Malformed KV JSON or KV transport errors return 503.
+
+The checked-in `wrangler.toml` omits the binding so `wrangler deploy --dry-run`
+still reports "No bindings found." — that remains the default transparent-proxy
+shape.
 
 ### Operational runbook
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12,8 +12,9 @@ can be agreed first.
   with prompt-data minimization and explicit retention controls.
 - Generate Rust and platform pricing tables from `pricing/catalog.json` instead
   of maintaining hand-written mirrors.
-- Add Workers KV or another reviewed source for globally distributed stateless
-  policy bundles; Worker v2.0.x reads vars/secrets, not KV.
+- ~~Add Workers KV or another reviewed source for globally distributed stateless
+  policy bundles~~ — implemented via optional `NOVEUM_GUARD_POLICIES_KV` binding
+  (see [Cloudflare Worker operations](CLOUDFLARE_WORKER.md)).
 - Add Bedrock tool/multimodal conversion and source-Region-aware strict pricing
   before expanding strict admission beyond the documented Claude surface.
 - Design streaming output-phase policy enforcement without losing backpressure

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ paths and native-only settings do not apply there.
 | Mode | Required settings | Forbidden settings | Runtime |
 |---|---|---|---|
 | Transparent | none | none | native or Worker |
-| Local policies | `NOVEUM_GUARD_POLICIES_FILE` or `NOVEUM_GUARD_POLICIES` | `NOVEUM_GUARD_TENANCY=shared`; do not also configure the dedicated platform pair | file: native only; inline: native or Worker |
+| Local policies | `NOVEUM_GUARD_POLICIES_FILE` or `NOVEUM_GUARD_POLICIES`; Worker may also use KV (`NOVEUM_GUARD_POLICIES_KV`, key `nova-guard-policies`) | `NOVEUM_GUARD_TENANCY=shared`; do not also configure the dedicated platform pair | file: native only; inline/KV: Worker |
 | Platform dedicated | `NOVEUM_API_KEY`, `NOVEUM_GUARD_PROJECT_ID`; optionally `NOVEUM_GUARD_TENANCY=dedicated` | `NOVEUM_GUARD_TENANCY=shared` | native or Worker |
 | Platform shared | `NOVEUM_GUARD_TENANCY=shared`; caller sends `x-noveum-api-key` | process-wide `NOVEUM_API_KEY`, `NOVEUM_GUARD_PROJECT_ID`, and local bundle | native only |
 
@@ -56,7 +56,8 @@ Configuration is read once. Restart or redeploy after changing it.
 |---|---|---|
 | `NOVEUM_GUARD_ENABLED` | `true` | Master switch. `false`, `0`, `no`, `off`, `disabled`, or an empty value disables the engine. |
 | `NOVEUM_GUARD_POLICIES_FILE` | unset | Native-only path to a JSON policy bundle. |
-| `NOVEUM_GUARD_POLICIES` | unset | Inline JSON policy bundle; on Workers, store sensitive bundles as a secret. |
+| `NOVEUM_GUARD_POLICIES` | unset | Inline JSON policy bundle; on Workers, store sensitive bundles as a secret. Fallback when KV is bound but the key is absent. |
+| `NOVEUM_GUARD_POLICIES_KV` | unset | Worker-only KV namespace binding. Fixed key `nova-guard-policies`. Optional; default deploy has no bindings. |
 | `NOVEUM_GUARD_BLOCK_RESPONSE_MODE` | `synthetic_success` | `synthetic_success` returns a refusal-shaped HTTP 200; `provider_error` returns an HTTP 403 error envelope. |
 | `NOVEUM_GUARD_ASSUMED_OUTPUT_TOKENS` | `1024` | Fallback estimate for advisory cost caps and rate-only accounting; never satisfies an applicable strict cost cap's explicit-bound requirement. |
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -83,6 +83,9 @@ pub mod middleware;
 /// repository cannot execute.
 pub mod worker_remote;
 
+/// Optional Workers KV policy bundle for the edge runtime (no platform bridge).
+pub mod worker_kv;
+
 pub use config::{Policy, PolicyBundle, PolicyType};
 pub use decision::{Phase, PolicyAction, PolicyDecision, PolicyMode, Severity};
 pub use engine::{EngineOptions, EvaluationResult, PolicyEngine};

--- a/src/policy/worker_kv.rs
+++ b/src/policy/worker_kv.rs
@@ -1,0 +1,284 @@
+//! Workers KV policy bundle loading for the Cloudflare Worker edge runtime.
+//!
+//! When the platform bridge ([`crate::policy::worker_remote`]) is **not**
+//! configured, an optional [`KV_BINDING_VAR`] namespace can hold the same
+//! `nova-guard.json` [`PolicyBundle`] schema the Worker already accepts via
+//! [`INLINE_POLICIES_VAR`]. Updates written to KV propagate globally without a
+//! Worker redeploy, subject to the in-isolate cache TTL below.
+//!
+//! Precedence (no platform bridge):
+//! 1. **KV** — non-empty value at [`KV_POLICY_KEY`], when the binding is present.
+//! 2. **Inline** — [`INLINE_POLICIES_VAR`] secret/var.
+//! 3. **Transparent** — empty bundle, identical to the checked-in default.
+//!
+//! A missing or whitespace-only KV value falls through to inline, then empty.
+//! Malformed JSON in KV or inline is a configuration error (`503`), never a
+//! silent pass-through. KV transport failures with the binding present are also
+//! configuration errors: the operator opted into KV as a policy source.
+//!
+//! With the platform bridge configured, the control plane remains the source of
+//! truth; any KV binding or inline bundle is ignored (with a warning).
+
+#[cfg(target_arch = "wasm32")]
+use std::rc::Rc;
+
+use crate::policy::config::PolicyBundle;
+
+#[cfg(target_arch = "wasm32")]
+use crate::policy::engine::{EngineOptions, PolicyEngine};
+
+/// Wrangler `kv_namespaces` binding name for the policy bundle namespace.
+///
+/// Example:
+/// ```toml
+/// [[kv_namespaces]]
+/// binding = "NOVEUM_GUARD_POLICIES_KV"
+/// id = "<namespace-id>"
+/// ```
+pub const KV_BINDING_VAR: &str = "NOVEUM_GUARD_POLICIES_KV";
+
+/// Fixed KV key holding the JSON policy bundle (`nova-guard.json` schema).
+pub const KV_POLICY_KEY: &str = "nova-guard-policies";
+
+/// Inline env/secret var (unchanged); fallback after an absent KV key.
+pub const INLINE_POLICIES_VAR: &str = "NOVEUM_GUARD_POLICIES";
+
+/// In-isolate reuse window before re-reading KV. Matches the platform policy
+/// cache cadence in [`crate::policy::worker_remote`] (~60 s).
+#[cfg(target_arch = "wasm32")]
+const KV_CACHE_TTL_MS: f64 = 60_000.0;
+
+/// Outcome of a KV policy lookup (binding present).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KvPolicyLookup {
+    /// The KV binding is not configured on this deployment.
+    NotConfigured,
+    /// Binding present; key missing or value is whitespace-only.
+    Absent,
+    /// Binding present; non-empty JSON text stored at [`KV_POLICY_KEY`].
+    Present(String),
+}
+
+/// Whether local (non-platform) policy sources are configured alongside the bridge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocalPolicySources {
+    pub kv_binding: bool,
+    pub inline: bool,
+}
+
+impl LocalPolicySources {
+    pub fn any(&self) -> bool {
+        self.kv_binding || self.inline
+    }
+}
+
+/// Resolve the effective local policy bundle when the platform bridge is off.
+///
+/// Validates JSON in precedence order: a present KV value is checked before
+/// inline is considered. Returns [`PolicyBundle::default()`] for a transparent
+/// proxy when neither source yields a non-empty bundle.
+pub fn resolve_policy_bundle(
+    kv: KvPolicyLookup,
+    inline: Option<String>,
+) -> Result<PolicyBundle, String> {
+    let inline = inline.filter(|s| !s.trim().is_empty());
+
+    if let KvPolicyLookup::Present(raw) = kv {
+        return PolicyBundle::from_json_str(&raw).map_err(|e| {
+            format!(
+                "Workers KV key `{KV_POLICY_KEY}` is set but is not a valid nova-guard bundle: {e}"
+            )
+        });
+    }
+
+    match inline {
+        None => Ok(PolicyBundle::default()),
+        Some(s) => PolicyBundle::from_json_str(&s).map_err(|e| {
+            format!("{INLINE_POLICIES_VAR} is set but is not a valid nova-guard bundle: {e}")
+        }),
+    }
+}
+
+#[derive(Clone)]
+#[cfg(target_arch = "wasm32")]
+struct CachedKvPolicy {
+    lookup: KvPolicyLookup,
+    fetched_ms: f64,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl CachedKvPolicy {
+    fn fresh(&self, now_ms: f64) -> bool {
+        now_ms - self.fetched_ms < KV_CACHE_TTL_MS
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_io {
+    use super::*;
+    use std::cell::RefCell;
+
+    use worker::{js_sys, Env, Result};
+
+    thread_local! {
+        static KV_POLICY_CACHE: RefCell<Option<CachedKvPolicy>> = const { RefCell::new(None) };
+    }
+
+    fn now_ms() -> f64 {
+        js_sys::Date::now()
+    }
+
+    /// True when `wrangler.toml` declares the [`KV_BINDING_VAR`] namespace.
+    pub fn kv_binding_present(env: &Env) -> bool {
+        env.kv(KV_BINDING_VAR).is_ok()
+    }
+
+    async fn read_kv_text(env: &Env) -> Result<KvPolicyLookup, String> {
+        let kv = env
+            .kv(KV_BINDING_VAR)
+            .map_err(|e| format!("Workers KV binding `{KV_BINDING_VAR}` is misconfigured: {e}"))?;
+        match kv.get(KV_POLICY_KEY).text().await {
+            Ok(Some(text)) if !text.trim().is_empty() => Ok(KvPolicyLookup::Present(text)),
+            Ok(Some(_)) | Ok(None) => Ok(KvPolicyLookup::Absent),
+            Err(e) => Err(format!("Workers KV read of `{KV_POLICY_KEY}` failed: {e}")),
+        }
+    }
+
+    async fn kv_policy_lookup(env: &Env) -> Result<KvPolicyLookup, String> {
+        if !kv_binding_present(env) {
+            return Ok(KvPolicyLookup::NotConfigured);
+        }
+
+        let now = now_ms();
+        if let Some(cached) = KV_POLICY_CACHE.with(|c| c.borrow().clone()) {
+            if cached.fresh(now) {
+                return Ok(cached.lookup);
+            }
+        }
+
+        let lookup = read_kv_text(env).await?;
+        KV_POLICY_CACHE.with(|c| {
+            *c.borrow_mut() = Some(CachedKvPolicy {
+                lookup: lookup.clone(),
+                fetched_ms: now_ms(),
+            });
+        });
+        Ok(lookup)
+    }
+
+    /// Build a Nova Guard engine from KV (when bound) and/or inline env, without
+    /// the platform bridge.
+    pub async fn local_policy_engine(
+        env: &Env,
+        opts: EngineOptions,
+        inline: Option<String>,
+    ) -> Result<Rc<PolicyEngine>, String> {
+        let kv = kv_policy_lookup(env).await?;
+        let bundle = resolve_policy_bundle(kv, inline)?;
+        Ok(Rc::new(PolicyEngine::from_bundle(&bundle, opts)))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm_io::{kv_binding_present, local_policy_engine};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = r#"{"policies":[{"name":"block","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"x","regex":"bad"}],"action":"block"}}]}"#;
+    const VALID_INLINE: &str = r#"{"policies":[{"name":"inline","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"y","regex":"inline"}],"action":"block"}}]}"#;
+
+    #[test]
+    fn kv_not_configured_falls_through_to_inline_then_empty() {
+        let bundle = resolve_policy_bundle(KvPolicyLookup::NotConfigured, None).unwrap();
+        assert!(bundle.policies.is_empty());
+
+        let bundle = resolve_policy_bundle(
+            KvPolicyLookup::NotConfigured,
+            Some(VALID_INLINE.to_string()),
+        )
+        .unwrap();
+        assert_eq!(bundle.policies.len(), 1);
+        assert_eq!(bundle.policies[0].name, "inline");
+    }
+
+    #[test]
+    fn absent_kv_key_falls_through_to_inline() {
+        let bundle = resolve_policy_bundle(KvPolicyLookup::Absent, None).unwrap();
+        assert!(bundle.policies.is_empty());
+
+        let bundle =
+            resolve_policy_bundle(KvPolicyLookup::Absent, Some(VALID_INLINE.to_string())).unwrap();
+        assert_eq!(bundle.policies[0].name, "inline");
+    }
+
+    #[test]
+    fn present_kv_wins_over_inline() {
+        let bundle = resolve_policy_bundle(
+            KvPolicyLookup::Present(VALID.to_string()),
+            Some(VALID_INLINE.to_string()),
+        )
+        .unwrap();
+        assert_eq!(bundle.policies.len(), 1);
+        assert_eq!(bundle.policies[0].name, "block");
+    }
+
+    #[test]
+    fn whitespace_only_kv_falls_through_to_inline() {
+        // Resolution treats whitespace-only as Absent before calling this helper.
+        let bundle =
+            resolve_policy_bundle(KvPolicyLookup::Absent, Some(VALID.to_string())).unwrap();
+        assert_eq!(bundle.policies.len(), 1);
+    }
+
+    #[test]
+    fn malformed_kv_is_a_configuration_error() {
+        let err = resolve_policy_bundle(
+            KvPolicyLookup::Present("{not json".to_string()),
+            Some(VALID.to_string()),
+        )
+        .unwrap_err();
+        assert!(err.contains(KV_POLICY_KEY), "{err}");
+        assert!(err.contains("not a valid nova-guard bundle"), "{err}");
+    }
+
+    #[test]
+    fn malformed_inline_is_a_configuration_error() {
+        let err =
+            resolve_policy_bundle(KvPolicyLookup::Absent, Some("{nope".to_string())).unwrap_err();
+        assert!(err.contains(INLINE_POLICIES_VAR), "{err}");
+    }
+
+    #[test]
+    fn local_sources_any_detects_kv_or_inline() {
+        assert!(!LocalPolicySources {
+            kv_binding: false,
+            inline: false,
+        }
+        .any());
+        assert!(LocalPolicySources {
+            kv_binding: true,
+            inline: false,
+        }
+        .any());
+        assert!(LocalPolicySources {
+            kv_binding: false,
+            inline: true,
+        }
+        .any());
+    }
+
+    #[test]
+    fn bridge_ignores_local_sources_when_platform_wins() {
+        // Documented contract: when bridge is on, local resolution is skipped.
+        // This test guards the pure helper used when bridge is off; platform
+        // precedence is enforced in `worker_rt`.
+        let bundle = resolve_policy_bundle(
+            KvPolicyLookup::Present(VALID.to_string()),
+            Some(VALID_INLINE.to_string()),
+        )
+        .unwrap();
+        assert_eq!(bundle.policies[0].name, "block");
+    }
+}

--- a/src/worker_rt.rs
+++ b/src/worker_rt.rs
@@ -19,10 +19,11 @@
 //!
 //! Both shapes are supported:
 //!
-//! * **Inline, stateless** — a `NOVEUM_GUARD_POLICIES` bundle of text rules
-//!   (`regex_match`, `pii_detection`, …), decided entirely from the payload in
-//!   front of us. An absent bundle is a transparent proxy; a *malformed* one is
-//!   a configuration error, never a silent pass-through.
+//! * **Local, stateless** — a policy bundle from optional Workers KV
+//!   ([`crate::policy::worker_kv`]) and/or inline `NOVEUM_GUARD_POLICIES`
+//!   text rules (`regex_match`, `pii_detection`, …), decided entirely from the
+//!   payload in front of us. An absent bundle is a transparent proxy; a
+//!   *malformed* one is a configuration error, never a silent pass-through.
 //! * **Platform-managed** (`NOVEUM_API_KEY` + `NOVEUM_GUARD_PROJECT_ID`) — the
 //!   effective policy set, live cost/rate counters and atomic admission come
 //!   from the Noveum control plane over `worker::Fetch`
@@ -69,6 +70,7 @@ use crate::policy::engine::EngineOptions;
 use crate::policy::metering::{extract_actual_usage_priced, ActualUsage, StreamUsageScanner};
 use crate::policy::rules::LiveState;
 use crate::policy::synthetic::{block_body, block_status, policy_header_token, BlockResponseMode};
+use crate::policy::worker_kv::{self, LocalPolicySources, INLINE_POLICIES_VAR};
 use crate::policy::worker_remote::{
     self, admit_request_body, assumed_output_tokens_from_value, force_include_usage,
     resolve_max_output_tokens, Admission, AdmitRequest, BodyAdmission, Settlement, StreamOutcome,
@@ -276,28 +278,29 @@ fn engine_options(env: &Env, live_state_backed: bool) -> EngineOptions {
     }
 }
 
-/// Build the Nova Guard engine from the in‑memory `NOVEUM_GUARD_POLICIES`
-/// bundle.
-///
-/// On the edge there is no filesystem. An *absent* bundle is a transparent
-/// pass‑through, exactly like the native `from_env`; a *present but malformed*
-/// one is a configuration error (`Err`) that the caller turns into a 503 —
-/// parsing it away would leave the operator believing the policies they deployed
-/// are in force.
-fn build_inline_engine(
-    env: &Env,
-    opts: EngineOptions,
-) -> core::result::Result<PolicyEngine, String> {
-    use crate::policy::config::PolicyBundle;
+fn local_policy_sources(env: &Env) -> LocalPolicySources {
+    LocalPolicySources {
+        kv_binding: worker_kv::kv_binding_present(env),
+        inline: env_value(env, INLINE_POLICIES_VAR).is_some_and(|s| !s.trim().is_empty()),
+    }
+}
 
-    let configured = env_value(env, "NOVEUM_GUARD_POLICIES").filter(|s| !s.trim().is_empty());
-    let bundle = match configured {
-        None => PolicyBundle::default(),
-        Some(s) => PolicyBundle::from_json_str(&s).map_err(|e| {
-            format!("NOVEUM_GUARD_POLICIES is set but is not a valid nova-guard bundle: {e}")
-        })?,
-    };
-    Ok(PolicyEngine::from_bundle(&bundle, opts))
+fn warn_ignored_local_policy_sources(sources: LocalPolicySources) {
+    if !sources.any() {
+        return;
+    }
+    let mut parts: Vec<&str> = Vec::new();
+    if sources.kv_binding {
+        parts.push("Workers KV policy binding");
+    }
+    if sources.inline {
+        parts.push(INLINE_POLICIES_VAR);
+    }
+    console_warn!(
+        "Nova Guard: both the platform bridge and {} are set; the platform's effective policy \
+         set wins and the local bundle is ignored",
+        parts.join(" and ")
+    );
 }
 
 /// Copy `src` headers into a fresh `Headers`, skipping any whose (lowercased)
@@ -946,13 +949,8 @@ async fn proxy(
         Some(cfg) => {
             // The platform is the source of truth once the bridge is configured:
             // an operator who pointed the Worker at a project did not ask for
-            // whatever happens to be inlined in `[vars]`.
-            if env_value(&env, "NOVEUM_GUARD_POLICIES").is_some_and(|s| !s.trim().is_empty()) {
-                console_warn!(
-                    "Nova Guard: both the platform bridge and NOVEUM_GUARD_POLICIES are set; the \
-                     platform's effective policy set wins and the inline bundle is ignored"
-                );
-            }
+            // whatever happens to be in KV or inlined in `[vars]`.
+            warn_ignored_local_policy_sources(local_policy_sources(&env));
             match worker_remote::effective_engine(cfg, opts.clone()).await {
                 Ok(engine) => engine,
                 Err(e) if env_flag(&env, ALLOW_UNGUARDED_START_VAR, false) => {
@@ -986,15 +984,18 @@ async fn proxy(
                 }
             }
         }
-        None => match build_inline_engine(&env, opts) {
-            Ok(engine) => Rc::new(engine),
-            // A malformed inline bundle is a configuration error, not a
-            // pass-through: proxying would silently drop every policy written.
-            Err(e) => {
-                console_error!("Nova Guard configuration error: {e}");
-                return unsupported_guard_config(&e);
+        None => {
+            let inline = env_value(&env, INLINE_POLICIES_VAR);
+            match worker_kv::local_policy_engine(&env, opts, inline).await {
+                Ok(engine) => engine,
+                // A malformed KV/inline bundle is a configuration error, not a
+                // pass-through: proxying would silently drop every policy written.
+                Err(e) => {
+                    console_error!("Nova Guard configuration error: {e}");
+                    return unsupported_guard_config(&e);
+                }
             }
-        },
+        }
     };
 
     let guard_active = engine.is_enabled() && engine.active_policy_count() > 0;
@@ -1005,13 +1006,13 @@ async fn proxy(
     let stateful = engine.is_enabled() && engine.stateful_policy_count() > 0;
     if stateful && bridge.is_none() {
         return unsupported_guard_config(
-            "NOVEUM_GUARD_POLICIES contains cost_cap/rate_limit policies, which cannot be enforced \
-             from an inline bundle on the Cloudflare Worker: they require a live cross-request \
-             state backend (spend/rate counters and an admission ledger) that an inline bundle \
-             does not have, so they would evaluate to `allow` on every request and `failClosed` \
-             could not be honored. Configure the platform bridge (NOVEUM_API_KEY + \
-             NOVEUM_GUARD_PROJECT_ID), which enforces them atomically across every PoP, or remove \
-             them from the inline bundle.",
+            "The local policy bundle (Workers KV or NOVEUM_GUARD_POLICIES) contains cost_cap/rate_limit \
+             policies, which cannot be enforced without the platform bridge on the Cloudflare Worker: \
+             they require a live cross-request state backend (spend/rate counters and an admission \
+             ledger) that a KV or inline bundle does not have, so they would evaluate to `allow` on \
+             every request and `failClosed` could not be honored. Configure the platform bridge \
+             (NOVEUM_API_KEY + NOVEUM_GUARD_PROJECT_ID), which enforces them atomically across every \
+             PoP, or remove them from the local bundle.",
         );
     }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -55,9 +55,22 @@ head_sampling_rate = 1
 # ---------------------------------------------------------------------------
 # Bindings and secrets
 # ---------------------------------------------------------------------------
-# This Worker needs NO Cloudflare resource bindings — no KV, no D1, no R2, no
-# Durable Objects, no queues. `wrangler deploy --dry-run` printing "No bindings
-# found." is the expected, correct output, not a misconfiguration.
+# The checked-in default needs NO Cloudflare resource bindings — no KV, no D1,
+# no R2, no Durable Objects, no queues. `wrangler deploy --dry-run` printing
+# "No bindings found." is the expected, correct output, not a misconfiguration.
+#
+# Optional: Workers KV for globally updatable stateless Nova Guard policies (no
+# redeploy to change the bundle). Create a namespace, then uncomment and set id:
+#
+# [[kv_namespaces]]
+# binding = "NOVEUM_GUARD_POLICIES_KV"
+# id = "<your-kv-namespace-id>"
+#
+# Store the bundle JSON at the fixed key `nova-guard-policies` (same schema as
+# native `nova-guard.json` / `NOVEUM_GUARD_POLICIES`). Precedence without the
+# platform bridge: KV (non-empty key) → inline `NOVEUM_GUARD_POLICIES` →
+# transparent empty bundle. A missing/empty KV key falls through to inline.
+# With the platform bridge configured, KV and inline are ignored (warning logged).
 #
 # Provider credentials are NOT stored here. The gateway is a pass-through proxy:
 # the caller's own provider key rides in on the request (`Authorization` /
@@ -73,9 +86,13 @@ head_sampling_rate = 1
 #                                   native `nova-guard.json`). Prefer
 #                                   `wrangler secret put NOVEUM_GUARD_POLICIES`
 #                                   when the patterns themselves are sensitive.
-#                                   IGNORED when the platform bridge below is
-#                                   configured (the platform is then the source
-#                                   of truth); the Worker logs a warning.
+#                                   Fallback after Workers KV when the optional
+#                                   `NOVEUM_GUARD_POLICIES_KV` binding is set
+#                                   but the `nova-guard-policies` key is absent
+#                                   or empty. IGNORED when the platform bridge
+#                                   below is configured; the Worker logs a warning.
+#   NOVEUM_GUARD_POLICIES_KV        Optional KV namespace binding (see above).
+#                                   Fixed key: `nova-guard-policies`.
 #   NOVEUM_GUARD_BLOCK_RESPONSE_MODE  `synthetic_success` | `provider_error`.
 #
 # Platform-managed Nova Guard (the "bridge"). BOTH are required, or neither —


### PR DESCRIPTION
## Problem

Follow-up to https://github.com/Noveum/ai-gateway/issues/29 (part 2 only).

The Cloudflare Worker loads stateless Nova Guard policies from the inline
`NOVEUM_GUARD_POLICIES` var/secret, which requires a redeploy to change.
Operators need an optional globally updatable source.

Intended outcome: optional Workers KV loading of the same `PolicyBundle` JSON
the Worker already accepts via `NOVEUM_GUARD_POLICIES`. Request routing and
Guard decision semantics are unchanged.

Telemetry (issue part 1) is out of scope.

## Approach

- Optional Wrangler binding `NOVEUM_GUARD_POLICIES_KV` (commented in
  `wrangler.toml`; default deploy stays binding-free).
- Fixed KV key: `nova-guard-policies` (same schema as `nova-guard.json` /
  `NOVEUM_GUARD_POLICIES`).
- Precedence without the platform bridge: KV (non-empty key) → inline
  `NOVEUM_GUARD_POLICIES` → transparent empty bundle.
- Missing/empty KV key falls through to inline, then empty.
- Platform bridge (`NOVEUM_API_KEY` + `NOVEUM_GUARD_PROJECT_ID`) still wins;
  KV and/or inline are ignored with a warning.
- Malformed KV or inline JSON, and KV transport errors when the binding is
  present, return 503.
- `cost_cap` / `rate_limit` in a KV bundle still require the platform bridge.
- ~60s in-isolate cache.

Code: `src/policy/worker_kv.rs`, `src/worker_rt.rs`.

## Security, tenancy, pricing, compatibility

- Additive Worker config only. Default deploy has no KV binding.
- Dedicated platform tenancy is unchanged. Shared tenancy remains refused on
  the Worker.
- No pricing catalog changes.
- Provider routing and Guard evaluation are unchanged.

## Documentation / changelog

- `docs/CLOUDFLARE_WORKER.md`
- `docs/CLOUDFLARE_DEPLOYMENT.md`
- `docs/configuration.md`
- `docs/TODO.md`
- `CHANGELOG.md` (Unreleased)

## Verification (exact head `bf53944`)

```bash
cargo fmt --all -- --check
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo test --locked --lib
cargo check --locked --target wasm32-unknown-unknown --no-default-features --lib
worker-build --release
npx --yes wrangler@4.120.0 deploy --dry-run
scripts/novaguard_worker_e2e.sh
```

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --locked --all-targets --all-features -- -D warnings` | pass |
| `cargo test --locked --lib` | pass (522 tests) |
| `cargo check --locked --target wasm32-unknown-unknown --no-default-features --lib` | pass |
| `worker-build --release` | pass |
| `npx --yes wrangler@4.120.0 deploy --dry-run` | pass (`No bindings found.`) |
| `scripts/novaguard_worker_e2e.sh` | pass (13/13 phases) |

Unit tests in `src/policy/worker_kv.rs` cover KV present, missing, malformed,
precedence over inline, and empty-bundle fallback.

## Live providers / runtimes

| Surface | Result |
|---|---|
| Local workerd (`wrangler dev` e2e) | tested |
| Live Cloudflare KV namespace | not tested |
| Paid provider smoke through a KV-backed Worker | not tested |
| Native gateway | not applicable (Worker-only wiring) |
| Edge telemetry sink | not tested (out of scope) |

## Rollout / rollback

Additive and optional. Omit the KV binding to keep a transparent proxy.
Rollback: revert this PR or remove the binding. Existing inline and
platform-bridge deployments are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Cloudflare Workers KV support for loading stateless Nova Guard policy bundles.
  - KV policies take precedence over inline policies; inline configuration remains the fallback when the KV entry is unavailable.
  - Platform-managed policies remain authoritative, and local KV or inline sources are ignored when configured.
  - Malformed or unreadable local policy data returns a 503 response when the platform bridge is not configured.

- **Documentation**
  - Added setup, configuration, precedence, fallback, and operational guidance for Workers KV policy bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->